### PR TITLE
feat: issue #138 power budget optimizer for low-battery + thermal modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This repository contains:
 - Compatibility runtime syscall allowlist scaffold with violation log export.
 - Delta update manifest schema validation (payload digest, base version, and fallback digest).
 - Telemetry privacy redaction engine for logs, metrics, and trace exports.
-- Device-profile boot budget enforcer with severity reporting for CI gates.
+- Device-profile boot budget enforcer with low-battery/thermal optimizer recommendations for CI gates.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,7 @@ Helper scripts for local development and automation live here.
 - `low_resource_profile_advisor.py`: recommends package profile by CPU/RAM class with rationale, tuning advice, and profile-manifest package preview JSON output.
 - `compat_runtime_allowlist.py`: compatibility runtime syscall allowlist scaffold with per-runtime counters and violation log export.
 - `telemetry_redaction_engine.py`: redacts sensitive fields from logs/metrics/traces and emits redaction summary telemetry.
-- `device_profile_boot_budget_enforcer.py`: enforces per-profile cold/warm boot budgets and emits pass/fail severity reports.
+- `device_profile_boot_budget_enforcer.py`: enforces per-profile cold/warm boot budgets and emits pass/fail severity reports with low-battery/thermal mode optimizer recommendations.
 - `installer_bootstrap_state_machine.py`: installer bootstrap state machine with recovery paths and attestation hook gating.
 - `package_repo_delta_apply_simulator.py`: simulates delta apply with digest validation and full-package fallback path.
 - `security_key_rotation_schedule_enforcer.py`: evaluates key age against rotation policy and emits warning/critical reports.

--- a/scripts/device_profile_boot_budget_enforcer.py
+++ b/scripts/device_profile_boot_budget_enforcer.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 ROOT = Path(__file__).resolve().parents[1]
 POLICY_PATH = ROOT / "packages" / "profiles" / "boot-budget-policy.json"
 PROFILES_DIR = ROOT / "packages" / "profiles"
+THERMAL_STATES = {"nominal", "elevated", "throttled"}
 
 
 def _load_profile_package_count(profile_name: str) -> int:
@@ -63,14 +64,86 @@ def _percentile(sorted_values: List[float], pct: float) -> float:
   return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * (idx - lo)
 
 
+def _resolve_mode(battery_percent: float, thermal_state: str) -> str:
+  if thermal_state == "throttled":
+    return "thermal_throttled"
+  if battery_percent <= 20.0:
+    return "low_battery"
+  if thermal_state == "elevated":
+    return "thermal_elevated"
+  return "balanced"
+
+
+def _recommend_actions(mode: str, profile_name: str, boot_type: str) -> List[Dict[str, object]]:
+  actions: List[Dict[str, object]] = []
+  if mode == "thermal_throttled":
+    actions.extend([
+        {
+            "action": "defer_noncritical_services",
+            "estimated_savings_s": 1.2,
+            "priority": "high",
+        },
+        {
+            "action": "reduce_parallel_startup_fanout",
+            "estimated_savings_s": 0.7,
+            "priority": "high",
+        },
+        {
+            "action": "enable_service_checkpoint_resume",
+            "estimated_savings_s": 0.4,
+            "priority": "medium",
+        },
+    ])
+  elif mode in {"low_battery", "thermal_elevated"}:
+    actions.extend([
+        {
+            "action": "switch_to_low_power_boot_profile",
+            "estimated_savings_s": 0.9,
+            "priority": "high",
+        },
+        {
+            "action": "delay_background_indexers",
+            "estimated_savings_s": 0.5,
+            "priority": "medium",
+        },
+    ])
+    if boot_type == "cold":
+      actions.append({
+          "action": "use_cached_driver_probe_results",
+          "estimated_savings_s": 0.3,
+          "priority": "medium",
+      })
+  if profile_name == "developer":
+    actions.append({
+        "action": "defer_optional_dev_tooling_units",
+        "estimated_savings_s": 0.6,
+        "priority": "medium",
+    })
+  return actions
+
+
+def _mode_budget_adjustment(mode: str) -> float:
+  if mode == "thermal_throttled":
+    return -1.2
+  if mode in {"low_battery", "thermal_elevated"}:
+    return -0.6
+  return 0.0
+
+
 def evaluate_boot_samples(profile_name: str,
                           boot_type: str,
                           samples_seconds: List[float],
+                          battery_percent: float = 100.0,
+                          thermal_state: str = "nominal",
                           policy: Dict[str, object] | None = None) -> Dict[str, object]:
   if policy is None:
     policy = load_budget_policy()
   if boot_type not in {"cold", "warm"}:
     raise ValueError("boot_type must be 'cold' or 'warm'")
+  if not isinstance(battery_percent, (int, float)) or battery_percent < 0 or battery_percent > 100:
+    raise ValueError("battery_percent must be in [0, 100]")
+  if thermal_state not in THERMAL_STATES:
+    raise ValueError(f"thermal_state must be one of {sorted(THERMAL_STATES)}")
   profiles = policy["profiles"]
   if profile_name not in profiles:
     raise ValueError(f"unknown profile: {profile_name}")
@@ -84,8 +157,10 @@ def evaluate_boot_samples(profile_name: str,
   budget_key = "cold_boot_budget_s" if boot_type == "cold" else "warm_boot_budget_s"
   budget = float(profiles[profile_name][budget_key])
   pkg_count = _load_profile_package_count(profile_name)
-  # Small dynamic slack to avoid false positives for heavier package compositions.
-  adjusted_budget = budget + max(0.0, (pkg_count - 5) * 0.15)
+  mode = _resolve_mode(float(battery_percent), thermal_state)
+  # Dynamic slack for heavier package compositions, plus mode pressure for thermal/battery constraints.
+  adjusted_budget = budget + max(0.0, (pkg_count - 5) * 0.15) + _mode_budget_adjustment(mode)
+  adjusted_budget = max(1.0, adjusted_budget)
   sorted_samples = sorted(samples)
   mean = sum(samples) / len(samples)
   p95 = _percentile(sorted_samples, 0.95)
@@ -99,10 +174,15 @@ def evaluate_boot_samples(profile_name: str,
       severity = "critical"
     else:
       severity = "warning"
+  recommendations = _recommend_actions(mode, profile_name, boot_type) if status == "fail" else []
+  estimated_recovery = round(sum(float(item["estimated_savings_s"]) for item in recommendations), 3)
   return {
       "schema_version": 1,
       "profile": profile_name,
       "boot_type": boot_type,
+      "power_mode": mode,
+      "battery_percent": round(float(battery_percent), 2),
+      "thermal_state": thermal_state,
       "sample_count": len(samples),
       "package_count": pkg_count,
       "base_budget_seconds": budget,
@@ -114,6 +194,8 @@ def evaluate_boot_samples(profile_name: str,
       "pass_rate": round(pass_rate, 4),
       "status": status,
       "severity": severity,
+      "optimizer_recommendations": recommendations,
+      "estimated_recovery_seconds": estimated_recovery,
       "recommendation": (
           "trim startup services and parallelize critical path"
           if status == "fail"
@@ -141,6 +223,8 @@ def evaluate_batch(batch_payload: Dict[str, object],
         profile_name=str(run.get("profile", "")),
         boot_type=str(run.get("boot_type", "")),
         samples_seconds=list(run.get("samples_seconds", [])),
+        battery_percent=float(run.get("battery_percent", 100.0)),
+        thermal_state=str(run.get("thermal_state", "nominal")),
         policy=policy,
     )
     reports.append(report)
@@ -170,6 +254,13 @@ def parse_args() -> argparse.Namespace:
   parser.add_argument("--boot-type", choices=["cold", "warm"], help="Boot type")
   parser.add_argument("--samples", help="Comma-separated sample seconds, e.g. 8.2,9.1,7.9")
   parser.add_argument("--batch-json", help="Path to batch input JSON")
+  parser.add_argument("--battery-percent", type=float, default=100.0, help="Battery percent [0-100]")
+  parser.add_argument(
+      "--thermal-state",
+      choices=sorted(THERMAL_STATES),
+      default="nominal",
+      help="Thermal state hint for optimizer",
+  )
   return parser.parse_args()
 
 
@@ -186,6 +277,8 @@ def main() -> int:
         profile_name=args.profile,
         boot_type=args.boot_type,
         samples_seconds=_parse_samples_arg(args.samples),
+        battery_percent=args.battery_percent,
+        thermal_state=args.thermal_state,
         policy=policy,
     )
   print(json.dumps(report, separators=(",", ":")))

--- a/tests/device_profile_boot_budget_enforcer_test.py
+++ b/tests/device_profile_boot_budget_enforcer_test.py
@@ -24,6 +24,7 @@ class DeviceProfileBootBudgetEnforcerTest(unittest.TestCase):
         self.assertEqual(report["status"], "pass")
         self.assertEqual(report["severity"], "ok")
         self.assertGreater(report["adjusted_budget_seconds"], 0)
+        self.assertEqual(report["power_mode"], "balanced")
 
     def test_single_run_fail_warning(self):
         report = module.evaluate_boot_samples(
@@ -38,14 +39,48 @@ class DeviceProfileBootBudgetEnforcerTest(unittest.TestCase):
     def test_batch_mixed(self):
         payload = {
             "runs": [
-                {"profile": "minimal", "boot_type": "warm", "samples_seconds": [6.0, 6.3, 6.5]},
-                {"profile": "developer", "boot_type": "cold", "samples_seconds": [31.0, 34.0, 33.0]},
+                {
+                    "profile": "minimal",
+                    "boot_type": "warm",
+                    "samples_seconds": [6.0, 6.3, 6.5],
+                    "battery_percent": 17.0,
+                },
+                {
+                    "profile": "developer",
+                    "boot_type": "cold",
+                    "samples_seconds": [31.0, 34.0, 33.0],
+                    "thermal_state": "throttled",
+                },
             ]
         }
         out = module.evaluate_batch(payload)
         self.assertEqual(out["total_runs"], 2)
         self.assertGreaterEqual(out["failed_runs"], 1)
         self.assertEqual(len(out["reports"]), 2)
+        self.assertIn(out["reports"][0]["power_mode"], {"low_battery", "balanced"})
+        self.assertIn(out["reports"][1]["power_mode"], {"thermal_throttled", "balanced"})
+
+    def test_optimizer_recommendations_on_thermal_fail(self):
+        report = module.evaluate_boot_samples(
+            profile_name="developer",
+            boot_type="cold",
+            samples_seconds=[33.0, 34.0, 35.0, 34.5],
+            battery_percent=55.0,
+            thermal_state="throttled",
+        )
+        self.assertEqual(report["status"], "fail")
+        self.assertEqual(report["power_mode"], "thermal_throttled")
+        self.assertGreater(len(report["optimizer_recommendations"]), 0)
+        self.assertGreater(report["estimated_recovery_seconds"], 0.0)
+
+    def test_invalid_thermal_state(self):
+        with self.assertRaises(ValueError):
+            module.evaluate_boot_samples(
+                profile_name="minimal",
+                boot_type="warm",
+                samples_seconds=[7.0, 7.1, 7.2],
+                thermal_state="very_hot",
+            )
 
     def test_cli_single(self):
         proc = subprocess.run(
@@ -58,6 +93,10 @@ class DeviceProfileBootBudgetEnforcerTest(unittest.TestCase):
                 "warm",
                 "--samples",
                 "10.2,10.7,11.1,10.0",
+                "--battery-percent",
+                "25",
+                "--thermal-state",
+                "elevated",
             ],
             cwd=str(ROOT),
             capture_output=True,
@@ -67,6 +106,7 @@ class DeviceProfileBootBudgetEnforcerTest(unittest.TestCase):
         payload = json.loads(proc.stdout.strip())
         self.assertEqual(payload["profile"], "server")
         self.assertEqual(payload["boot_type"], "warm")
+        self.assertEqual(payload["thermal_state"], "elevated")
 
     def test_cli_batch(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -84,6 +124,8 @@ class DeviceProfileBootBudgetEnforcerTest(unittest.TestCase):
                                 "profile": "desktop",
                                 "boot_type": "warm",
                                 "samples_seconds": [12.0, 12.4, 12.1, 12.3],
+                                "battery_percent": 15.0,
+                                "thermal_state": "elevated",
                             },
                         ]
                     }
@@ -100,6 +142,7 @@ class DeviceProfileBootBudgetEnforcerTest(unittest.TestCase):
             payload = json.loads(proc.stdout.strip())
             self.assertEqual(payload["schema_version"], 1)
             self.assertEqual(payload["total_runs"], 2)
+            self.assertIn("power_mode", payload["reports"][1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add mode-aware power budget optimizer in boot budget enforcer
- include low-battery and thermal-state aware budget pressure
- emit prioritized optimizer recommendations with estimated recovery
- extend CLI and batch payloads with battery/thermal fields
- add regression tests for optimizer behavior

## Validation
- python -m pytest -q tests/device_profile_boot_budget_enforcer_test.py
- python scripts/validate_packages.py
- python -m pytest -q

Closes #138