### PR TITLE
feat: issue #141 restart supervisor health probe + metrics export

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This repository contains:
 - Delta update manifest schema validation (payload digest, base version, and fallback digest).
 - Telemetry privacy redaction engine for logs, metrics, and trace exports.
 - Device-profile boot budget enforcer with low-battery/thermal optimizer recommendations for CI gates.
+- Service restart budget supervisor with health-probe and metrics-export JSON endpoints for ops dashboards.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,7 +20,7 @@ Helper scripts for local development and automation live here.
 - `installer_bootstrap_state_machine.py`: installer bootstrap state machine with recovery paths and attestation hook gating.
 - `package_repo_delta_apply_simulator.py`: simulates delta apply with digest validation and full-package fallback path.
 - `security_key_rotation_schedule_enforcer.py`: evaluates key age against rotation policy and emits warning/critical reports.
-- `service_restart_budget_supervisor.py`: enforces per-service restart budgets with sliding windows, backoff, escalation, and incident reports.
+- `service_restart_budget_supervisor.py`: enforces per-service restart budgets with sliding windows, backoff, escalation, incident reports, plus JSON health-probe and metrics-export endpoints.
 - `package_signature_verifier.py`: verifies HMAC-SHA256 package signatures from repository index entries using keyring input.
 - `sandbox_escape_fuzz_corpus.py`: generates deterministic path+DNS sandbox-escape fuzz corpus from seed sets with reason-coded expected blocks.
 - `scheduler_turbo_benchmark.py`: deterministic benchmark comparing round-robin vs turbo scheduler latency metrics.

--- a/scripts/service_restart_budget_supervisor.py
+++ b/scripts/service_restart_budget_supervisor.py
@@ -21,6 +21,10 @@ class ServiceRuntimeState:
   consecutive_failures: int = 0
   cooldown_until: int = 0
   escalated: bool = False
+  last_exit_code: int = 0
+  last_exit_timestamp: int = 0
+  last_action: str = "init"
+  freeze_count: int = 0
 
 
 @dataclass
@@ -38,6 +42,7 @@ class ServiceRestartBudgetSupervisor:
   states: Dict[str, ServiceRuntimeState] = field(default_factory=dict)
   incidents: List[RestartIncident] = field(default_factory=list)
   decision_count: int = 0
+  freeze_decision_count: int = 0
 
   @staticmethod
   def _require_int(value: object, field_name: str, minimum: int = 0) -> int:
@@ -113,11 +118,14 @@ class ServiceRestartBudgetSupervisor:
       raise ValueError("unknown service")
     self.decision_count += 1
     self._prune_restart_window(policy, state, timestamp_epoch)
+    state.last_exit_code = exit_code
+    state.last_exit_timestamp = timestamp_epoch
 
     if exit_code == 0:
       state.consecutive_failures = 0
       state.escalated = False
       state.cooldown_until = timestamp_epoch
+      state.last_action = "no_restart_needed"
       return {
           "service": service,
           "action": "no_restart_needed",
@@ -128,6 +136,8 @@ class ServiceRestartBudgetSupervisor:
 
     if len(state.restart_timestamps) >= policy.max_restarts:
       state.escalated = True
+      self.freeze_decision_count += 1
+      state.freeze_count += 1
       incident = RestartIncident(
           service=service,
           timestamp_epoch=timestamp_epoch,
@@ -141,6 +151,7 @@ class ServiceRestartBudgetSupervisor:
       )
       self.incidents.append(incident)
       state.cooldown_until = timestamp_epoch + policy.max_backoff_seconds
+      state.last_action = "freeze"
       return {
           "service": service,
           "action": "freeze",
@@ -156,6 +167,7 @@ class ServiceRestartBudgetSupervisor:
       state.escalated = True
     delay = self._compute_backoff(policy, state, timestamp_epoch)
     state.cooldown_until = timestamp_epoch + delay
+    state.last_action = "restart_after_backoff"
     return {
         "service": service,
         "action": "restart_after_backoff",
@@ -167,10 +179,99 @@ class ServiceRestartBudgetSupervisor:
         "escalated": 1 if state.escalated else 0,
     }
 
+  def _service_health(self, service: str, now_epoch: int) -> Dict[str, object]:
+    if service not in self.policies:
+      raise ValueError("unknown service")
+    policy = self.policies[service]
+    state = self.states[service]
+    self._prune_restart_window(policy, state, now_epoch)
+    restart_pressure = 0.0
+    if policy.max_restarts > 0:
+      restart_pressure = min(1.0, len(state.restart_timestamps) / policy.max_restarts)
+    cooldown_remaining = max(0, state.cooldown_until - now_epoch)
+    status = "healthy"
+    if state.last_action == "freeze":
+      status = "frozen"
+    elif state.escalated or restart_pressure >= 0.75 or cooldown_remaining > 0:
+      status = "degraded"
+    reason = "within_budget"
+    if status == "frozen":
+      reason = "restart_budget_exhausted"
+    elif state.escalated:
+      reason = "escalation_threshold_hit"
+    elif cooldown_remaining > 0:
+      reason = "backoff_cooldown_active"
+    elif restart_pressure >= 0.75:
+      reason = "restart_budget_pressure"
+    return {
+        "service": service,
+        "status": status,
+        "reason": reason,
+        "restart_pressure": round(restart_pressure, 4),
+        "cooldown_remaining_seconds": cooldown_remaining,
+        "window_failures": len(state.restart_timestamps),
+        "consecutive_failures": state.consecutive_failures,
+        "escalated": 1 if state.escalated else 0,
+        "freeze_count": state.freeze_count,
+        "last_exit_code": state.last_exit_code,
+        "last_exit_timestamp": state.last_exit_timestamp,
+        "last_action": state.last_action,
+    }
+
+  def health_probe_json(self, now_epoch: int) -> str:
+    probes = [self._service_health(service, now_epoch) for service in sorted(self.policies.keys())]
+    unhealthy = sum(1 for p in probes if p["status"] in {"degraded", "frozen"})
+    payload = {
+        "schema_version": 1,
+        "timestamp_epoch": now_epoch,
+        "service_count": len(probes),
+        "unhealthy_count": unhealthy,
+        "healthy_count": len(probes) - unhealthy,
+        "global_status": "healthy" if unhealthy == 0 else "degraded",
+        "services": probes,
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+  def metrics_export_json(self, now_epoch: int) -> str:
+    probes = [self._service_health(service, now_epoch) for service in sorted(self.policies.keys())]
+    degraded = sum(1 for p in probes if p["status"] == "degraded")
+    frozen = sum(1 for p in probes if p["status"] == "frozen")
+    max_restart_pressure = max((float(p["restart_pressure"]) for p in probes), default=0.0)
+    availability_score = 1.0
+    if probes:
+      availability_score = max(0.0, 1.0 - ((degraded * 0.5 + frozen) / len(probes)))
+    payload = {
+        "schema_version": 1,
+        "timestamp_epoch": now_epoch,
+        "counters": {
+            "decision_count": self.decision_count,
+            "incident_count": len(self.incidents),
+            "freeze_decision_count": self.freeze_decision_count,
+            "degraded_service_count": degraded,
+            "frozen_service_count": frozen,
+        },
+        "gauges": {
+            "service_count": len(probes),
+            "max_restart_pressure": round(max_restart_pressure, 4),
+            "availability_score": round(availability_score, 4),
+        },
+        "services": [
+            {
+                "service": p["service"],
+                "status": p["status"],
+                "restart_pressure": p["restart_pressure"],
+                "cooldown_remaining_seconds": p["cooldown_remaining_seconds"],
+            }
+            for p in probes
+        ],
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
   def summary_json(self) -> str:
     payload = {
         "schema_version": 1,
         "decision_count": self.decision_count,
+        "freeze_decision_count": self.freeze_decision_count,
         "service_count": len(self.policies),
         "incident_count": len(self.incidents),
         "services": {
@@ -185,6 +286,10 @@ class ServiceRestartBudgetSupervisor:
                 "consecutive_failures": self.states[name].consecutive_failures,
                 "window_failures": len(self.states[name].restart_timestamps),
                 "escalated": 1 if self.states[name].escalated else 0,
+                "freeze_count": self.states[name].freeze_count,
+                "last_action": self.states[name].last_action,
+                "last_exit_code": self.states[name].last_exit_code,
+                "last_exit_timestamp": self.states[name].last_exit_timestamp,
             }
             for name, policy in self.policies.items()
         },

--- a/tests/service_restart_budget_supervisor_test.py
+++ b/tests/service_restart_budget_supervisor_test.py
@@ -86,7 +86,37 @@ class ServiceRestartBudgetSupervisorTest(unittest.TestCase):
         self.assertEqual(payload["schema_version"], 1)
         self.assertGreaterEqual(payload["decision_count"], 3)
         self.assertEqual(payload["incident_count"], 1)
+        self.assertEqual(payload["freeze_decision_count"], 1)
         self.assertIn("network-agent", payload["services"])
+        self.assertEqual(payload["services"]["network-agent"]["last_action"], "freeze")
+
+    def test_health_probe_json_exposes_service_status(self):
+        self.supervisor.record_exit("ui-shell", exit_code=1, timestamp_epoch=1000)
+        self.supervisor.record_exit("network-agent", exit_code=1, timestamp_epoch=1000)
+        self.supervisor.record_exit("network-agent", exit_code=1, timestamp_epoch=1001)
+        self.supervisor.record_exit("network-agent", exit_code=1, timestamp_epoch=1002)
+        probe = json.loads(self.supervisor.health_probe_json(now_epoch=1003))
+        self.assertEqual(probe["schema_version"], 1)
+        self.assertEqual(probe["service_count"], 2)
+        self.assertGreaterEqual(probe["unhealthy_count"], 1)
+        services = {entry["service"]: entry for entry in probe["services"]}
+        self.assertIn(services["network-agent"]["status"], {"degraded", "frozen"})
+        self.assertIn("restart_pressure", services["ui-shell"])
+
+    def test_metrics_export_json_contains_ops_counters(self):
+        self.supervisor.record_exit("ui-shell", exit_code=1, timestamp_epoch=1200)
+        self.supervisor.record_exit("ui-shell", exit_code=1, timestamp_epoch=1202)
+        self.supervisor.record_exit("network-agent", exit_code=1, timestamp_epoch=1200)
+        self.supervisor.record_exit("network-agent", exit_code=1, timestamp_epoch=1201)
+        self.supervisor.record_exit("network-agent", exit_code=1, timestamp_epoch=1202)
+        metrics = json.loads(self.supervisor.metrics_export_json(now_epoch=1203))
+        self.assertEqual(metrics["schema_version"], 1)
+        self.assertIn("counters", metrics)
+        self.assertIn("gauges", metrics)
+        self.assertGreaterEqual(metrics["counters"]["decision_count"], 5)
+        self.assertGreaterEqual(metrics["counters"]["freeze_decision_count"], 1)
+        self.assertGreaterEqual(metrics["gauges"]["service_count"], 2)
+        self.assertGreaterEqual(metrics["gauges"]["max_restart_pressure"], 0.0)
 
     def test_manifest_validation_rejects_bad_shapes(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- add supervisor health probe JSON endpoint for ops dashboards
- add metrics export JSON endpoint with counters/gauges/service slices
- track per-service last action/exit metadata and freeze counters
- extend summary payload with new observability fields
- add tests for health/metrics export behavior

## Validation
- python -m pytest -q tests/service_restart_budget_supervisor_test.py
- python scripts/validate_packages.py
- python -m pytest -q

Closes #141