### PR TITLE
feat: issue #142 kernel checkpoint journal persistence and replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This repository contains:
 - Telemetry privacy redaction engine for logs, metrics, and trace exports.
 - Device-profile boot budget enforcer with low-battery/thermal optimizer recommendations for CI gates.
 - Service restart budget supervisor with health-probe and metrics-export JSON endpoints for ops dashboards.
+- Kernel checkpoint journal persistence + replay path for crash-recovery boot restore.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -30,3 +30,8 @@ Kernel direction, interfaces, and implementation notes live here.
   - includes tick-based wait-time and last-latency counters per process.
   - includes aggregate wait report (`mean`, `p95`, `max`) for tuning and diagnostics.
   - includes wait-report snapshot endpoint with capture tick and queue metadata.
+- `aegis_process_checkpoint_table_t`: process checkpoint capture/restore for recovery workflows.
+  - supports process runtime registration and per-reason checkpoint capture.
+  - supports checkpoint restore with epoch verification and failure counters.
+  - exposes snapshot JSON endpoint with entry-level checkpoint metadata.
+  - supports disk-backed journal save and boot-time replay for crash recovery.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -490,6 +490,11 @@ int aegis_process_checkpoint_query(const aegis_process_checkpoint_table_t *table
 int aegis_process_checkpoint_snapshot_json(const aegis_process_checkpoint_table_t *table,
                                           char *out,
                                           size_t out_size);
+int aegis_process_checkpoint_journal_save(const aegis_process_checkpoint_table_t *table,
+                                          const char *journal_path);
+int aegis_process_checkpoint_journal_replay(aegis_process_checkpoint_table_t *table,
+                                            const char *journal_path,
+                                            uint8_t apply_runtime_states);
 void aegis_secure_time_attestor_init(aegis_secure_time_attestor_t *attestor,
                                      uint32_t boot_id,
                                      uint64_t baseline_wallclock_epoch,

--- a/kernel/src/process_checkpoint.c
+++ b/kernel/src/process_checkpoint.c
@@ -1,6 +1,7 @@
 #include "kernel.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 static int runtime_index_for_pid(const aegis_process_checkpoint_table_t *table,
@@ -40,6 +41,29 @@ static int checkpoint_index_for_pid(const aegis_process_checkpoint_table_t *tabl
 static int valid_checkpoint_reason(uint8_t reason) {
   return reason >= AEGIS_CHECKPOINT_REASON_MANUAL &&
          reason <= AEGIS_CHECKPOINT_REASON_AUTOMATED_RECOVERY;
+}
+
+static void sanitize_tag_for_journal(const char *in_tag, char *out_tag, size_t out_size) {
+  size_t i;
+  if (out_tag == 0 || out_size == 0u) {
+    return;
+  }
+  if (in_tag == 0 || in_tag[0] == '\0') {
+    snprintf(out_tag, out_size, "%s", "-");
+    return;
+  }
+  for (i = 0; i + 1u < out_size && in_tag[i] != '\0'; ++i) {
+    char ch = in_tag[i];
+    if (ch == ' ' || ch == '\t' || ch == '|' || ch == '\n' || ch == '\r') {
+      out_tag[i] = '_';
+    } else {
+      out_tag[i] = ch;
+    }
+  }
+  out_tag[i] = '\0';
+  if (out_tag[0] == '\0') {
+    snprintf(out_tag, out_size, "%s", "-");
+  }
 }
 
 void aegis_process_checkpoint_table_init(aegis_process_checkpoint_table_t *table) {
@@ -226,4 +250,189 @@ int aegis_process_checkpoint_snapshot_json(const aegis_process_checkpoint_table_
   }
   offset += (size_t)written;
   return (int)offset;
+}
+
+int aegis_process_checkpoint_journal_save(const aegis_process_checkpoint_table_t *table,
+                                          const char *journal_path) {
+  FILE *f = 0;
+  size_t i;
+  if (table == 0 || journal_path == 0 || journal_path[0] == '\0') {
+    return -1;
+  }
+  f = fopen(journal_path, "wb");
+  if (f == 0) {
+    return -1;
+  }
+  if (fprintf(f,
+              "AEGIS_CHECKPOINT_JOURNAL_V1 %llu %llu %llu %llu\n",
+              (unsigned long long)table->next_epoch,
+              (unsigned long long)table->capture_count,
+              (unsigned long long)table->restore_count,
+              (unsigned long long)table->restore_failures) < 0) {
+    fclose(f);
+    return -1;
+  }
+  for (i = 0; i < AEGIS_PROCESS_CHECKPOINT_CAPACITY; ++i) {
+    const aegis_process_checkpoint_entry_t *entry = &table->checkpoints[i];
+    char tag[AEGIS_PROCESS_CHECKPOINT_TAG_MAX];
+    if (entry->valid == 0u) {
+      continue;
+    }
+    sanitize_tag_for_journal(entry->tag, tag, sizeof(tag));
+    if (fprintf(f,
+                "E %u %llu %llu %u %u %u %u %u %llu %u %llu %llu %u %s\n",
+                entry->process_id,
+                (unsigned long long)entry->checkpoint_epoch,
+                (unsigned long long)entry->captured_at_tick,
+                (unsigned int)entry->reason,
+                (unsigned int)entry->restore_count,
+                (unsigned int)entry->last_restore_status,
+                entry->state.namespace_id,
+                entry->state.thread_count,
+                (unsigned long long)entry->state.vm_bytes,
+                entry->state.capability_mask,
+                (unsigned long long)entry->state.policy_revision,
+                (unsigned long long)entry->state.scheduler_tick,
+                (unsigned int)entry->state.active,
+                tag) < 0) {
+      fclose(f);
+      return -1;
+    }
+  }
+  if (fclose(f) != 0) {
+    return -1;
+  }
+  return 0;
+}
+
+int aegis_process_checkpoint_journal_replay(aegis_process_checkpoint_table_t *table,
+                                            const char *journal_path,
+                                            uint8_t apply_runtime_states) {
+  FILE *f = 0;
+  char line[512];
+  uint64_t next_epoch = 1u;
+  uint64_t capture_count = 0u;
+  uint64_t restore_count = 0u;
+  uint64_t restore_failures = 0u;
+  unsigned long long next_epoch_raw = 0u;
+  unsigned long long capture_count_raw = 0u;
+  unsigned long long restore_count_raw = 0u;
+  unsigned long long restore_failures_raw = 0u;
+  uint64_t max_epoch_seen = 0u;
+  size_t checkpoint_cursor = 0u;
+  if (table == 0 || journal_path == 0 || journal_path[0] == '\0') {
+    return -1;
+  }
+  f = fopen(journal_path, "rb");
+  if (f == 0) {
+    return -1;
+  }
+  if (fgets(line, sizeof(line), f) == 0) {
+    fclose(f);
+    return -1;
+  }
+  if (sscanf(line,
+             "AEGIS_CHECKPOINT_JOURNAL_V1 %llu %llu %llu %llu",
+             &next_epoch_raw,
+             &capture_count_raw,
+             &restore_count_raw,
+             &restore_failures_raw) != 4) {
+    fclose(f);
+    return -1;
+  }
+  next_epoch = (uint64_t)next_epoch_raw;
+  capture_count = (uint64_t)capture_count_raw;
+  restore_count = (uint64_t)restore_count_raw;
+  restore_failures = (uint64_t)restore_failures_raw;
+  aegis_process_checkpoint_table_init(table);
+  table->capture_count = capture_count;
+  table->restore_count = restore_count;
+  table->restore_failures = restore_failures;
+  while (fgets(line, sizeof(line), f) != 0) {
+    unsigned int process_id = 0u;
+    unsigned long long checkpoint_epoch = 0u;
+    unsigned long long captured_at_tick = 0u;
+    unsigned int reason = 0u;
+    unsigned int restore_count_u32 = 0u;
+    unsigned int last_restore_status = 0u;
+    unsigned int namespace_id = 0u;
+    unsigned int thread_count = 0u;
+    unsigned long long vm_bytes = 0u;
+    unsigned int capability_mask = 0u;
+    unsigned long long policy_revision = 0u;
+    unsigned long long scheduler_tick = 0u;
+    unsigned int active = 0u;
+    char tag[AEGIS_PROCESS_CHECKPOINT_TAG_MAX] = {0};
+    aegis_process_checkpoint_entry_t *entry = 0;
+    if (line[0] == '\0' || line[0] == '\n' || line[0] == '\r') {
+      continue;
+    }
+    if (line[0] != 'E' || line[1] != ' ') {
+      fclose(f);
+      return -1;
+    }
+    if (sscanf(line,
+               "E %u %llu %llu %u %u %u %u %u %llu %u %llu %llu %u %47s",
+               &process_id,
+               &checkpoint_epoch,
+               &captured_at_tick,
+               &reason,
+               &restore_count_u32,
+               &last_restore_status,
+               &namespace_id,
+               &thread_count,
+               &vm_bytes,
+               &capability_mask,
+               &policy_revision,
+               &scheduler_tick,
+               &active,
+               tag) != 14) {
+      fclose(f);
+      return -1;
+    }
+    if (!valid_checkpoint_reason((uint8_t)reason) ||
+        checkpoint_cursor >= AEGIS_PROCESS_CHECKPOINT_CAPACITY ||
+        process_id == 0u) {
+      fclose(f);
+      return -1;
+    }
+    entry = &table->checkpoints[checkpoint_cursor];
+    memset(entry, 0, sizeof(*entry));
+    entry->process_id = (uint32_t)process_id;
+    entry->checkpoint_epoch = (uint64_t)checkpoint_epoch;
+    entry->captured_at_tick = (uint64_t)captured_at_tick;
+    entry->reason = (uint8_t)reason;
+    entry->restore_count = (uint8_t)restore_count_u32;
+    entry->last_restore_status = (uint8_t)last_restore_status;
+    entry->state.process_id = (uint32_t)process_id;
+    entry->state.namespace_id = (uint32_t)namespace_id;
+    entry->state.thread_count = (uint32_t)thread_count;
+    entry->state.vm_bytes = (uint64_t)vm_bytes;
+    entry->state.capability_mask = (uint32_t)capability_mask;
+    entry->state.policy_revision = (uint64_t)policy_revision;
+    entry->state.scheduler_tick = (uint64_t)scheduler_tick;
+    entry->state.active = (uint8_t)(active != 0u ? 1u : 0u);
+    if (strcmp(tag, "-") == 0) {
+      entry->tag[0] = '\0';
+    } else {
+      snprintf(entry->tag, sizeof(entry->tag), "%s", tag);
+    }
+    entry->valid = 1u;
+    if (apply_runtime_states != 0u) {
+      if (aegis_process_checkpoint_register_runtime(table, &entry->state) != 0) {
+        fclose(f);
+        return -1;
+      }
+    }
+    if (entry->checkpoint_epoch > max_epoch_seen) {
+      max_epoch_seen = entry->checkpoint_epoch;
+    }
+    checkpoint_cursor += 1u;
+  }
+  fclose(f);
+  table->next_epoch = next_epoch;
+  if (table->next_epoch <= max_epoch_seen) {
+    table->next_epoch = max_epoch_seen + 1u;
+  }
+  return 0;
 }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -1296,6 +1296,77 @@ static int test_process_checkpoint_restore_scaffold(void) {
   return 0;
 }
 
+static int test_process_checkpoint_journal_persistence_and_replay(void) {
+  aegis_process_checkpoint_table_t source;
+  aegis_process_checkpoint_table_t replayed;
+  aegis_process_runtime_state_t runtime;
+  aegis_process_runtime_state_t restored;
+  aegis_process_checkpoint_entry_t entry;
+  uint64_t epoch = 0u;
+  const char *journal_path = "checkpoint_journal_test.log";
+  char json[4096];
+  memset(&runtime, 0, sizeof(runtime));
+  memset(&restored, 0, sizeof(restored));
+  memset(&entry, 0, sizeof(entry));
+  aegis_process_checkpoint_table_init(&source);
+  runtime.process_id = 12001u;
+  runtime.namespace_id = 44u;
+  runtime.thread_count = 6u;
+  runtime.vm_bytes = 96u * 1024u * 1024u;
+  runtime.capability_mask = 0x3Fu;
+  runtime.policy_revision = 19u;
+  runtime.scheduler_tick = 888u;
+  runtime.active = 1u;
+  if (aegis_process_checkpoint_register_runtime(&source, &runtime) != 0) {
+    fprintf(stderr, "checkpoint journal register runtime failed\n");
+    return 1;
+  }
+  if (aegis_process_checkpoint_capture(&source,
+                                       12001u,
+                                       AEGIS_CHECKPOINT_REASON_AUTOMATED_RECOVERY,
+                                       901u,
+                                       "crash-recovery",
+                                       &epoch) != 0 ||
+      epoch == 0u) {
+    fprintf(stderr, "checkpoint journal capture failed\n");
+    return 1;
+  }
+  if (aegis_process_checkpoint_journal_save(&source, journal_path) != 0) {
+    fprintf(stderr, "checkpoint journal save failed\n");
+    return 1;
+  }
+  if (aegis_process_checkpoint_journal_replay(&replayed, journal_path, 1u) != 0) {
+    fprintf(stderr, "checkpoint journal replay failed\n");
+    remove(journal_path);
+    return 1;
+  }
+  if (aegis_process_checkpoint_query(&replayed, 12001u, &entry) != 0 ||
+      entry.checkpoint_epoch != epoch ||
+      entry.state.vm_bytes != runtime.vm_bytes ||
+      strcmp(entry.tag, "crash-recovery") != 0) {
+    fprintf(stderr, "checkpoint journal replayed entry mismatch\n");
+    remove(journal_path);
+    return 1;
+  }
+  if (aegis_process_checkpoint_restore(&replayed, 12001u, epoch, &restored) != 0 ||
+      restored.process_id != runtime.process_id ||
+      restored.scheduler_tick != runtime.scheduler_tick) {
+    fprintf(stderr, "checkpoint journal replayed restore mismatch\n");
+    remove(journal_path);
+    return 1;
+  }
+  if (aegis_process_checkpoint_snapshot_json(&replayed, json, sizeof(json)) <= 0 ||
+      strstr(json, "\"capture_count\":1") == 0 ||
+      strstr(json, "\"restore_count\":1") == 0 ||
+      strstr(json, "\"tag\":\"crash-recovery\"") == 0) {
+    fprintf(stderr, "checkpoint journal replay snapshot mismatch: %s\n", json);
+    remove(journal_path);
+    return 1;
+  }
+  remove(journal_path);
+  return 0;
+}
+
 static int test_secure_time_source_attestation(void) {
   aegis_secure_time_attestor_t attestor;
   aegis_secure_time_attestation_result_t result;
@@ -1438,6 +1509,9 @@ int main(void) {
     return 1;
   }
   if (test_process_checkpoint_restore_scaffold() != 0) {
+    return 1;
+  }
+  if (test_process_checkpoint_journal_persistence_and_replay() != 0) {
     return 1;
   }
   if (test_secure_time_source_attestation() != 0) {


### PR DESCRIPTION
## Summary
- add disk-backed checkpoint journal save API for process checkpoint table
- add boot-time replay API to restore checkpoint entries and runtime state
- define journal format header + entry records with validation guards
- extend kernel simulation tests with persistence/replay crash-recovery path
- update kernel and root docs for checkpoint journal support

## Validation
- python scripts/run_clang_suite.py
- python scripts/validate_packages.py
- python -m pytest -q

Closes #142