### PR TITLE
feat: issue #152 scheduler hot-path live counters optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This repository contains:
 - Device-profile boot budget enforcer with low-battery/thermal optimizer recommendations for CI gates.
 - Service restart budget supervisor with health-probe and metrics-export JSON endpoints for ops dashboards.
 - Kernel checkpoint journal persistence + replay path for crash-recovery boot restore.
+- Scheduler hot-path optimization via live priority/runnable-credit counters for faster dispatch bookkeeping.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -12,6 +12,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - supports fixed-size encode/decode and schema/payload validation checks.
   - includes payload-fit guard helper for max-frame enforcement.
 - `aegis_scheduler_t`: weighted round-robin scheduler with priority-aware dispatch.
+  - optimized hot-path dispatch bookkeeping with live `priority_counts` and `runnable_credit_count` counters to reduce full-queue scans.
   - includes optional `turbo` dispatch strategy that scores queue entries by priority + wait time for lower tail latency.
   - turbo mode retains fairness pressure by debiasing over-dispatched processes and preserving credit-based limits.
   - turbo mode includes adaptive weight autotuning to rebalance `priority` vs `wait` based on live latency telemetry.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -43,7 +43,9 @@ typedef struct {
   uint8_t priorities[64];
   uint8_t credits[64];
   uint8_t admission_limits[4];
+  uint8_t priority_counts[4];
   uint64_t admission_drops[4];
+  uint16_t runnable_credit_count;
   uint8_t admission_profile_id;
   uint32_t dispatch_counts[64];
   uint64_t enqueued_tick[64];

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -329,21 +329,20 @@ static int priority_bucket_index(uint8_t priority) {
 }
 
 static uint8_t scheduler_priority_member_count(const aegis_scheduler_t *scheduler, uint8_t priority) {
-  size_t i;
-  uint8_t count = 0u;
+  int bucket;
   if (scheduler == 0) {
     return 0u;
   }
-  for (i = 0; i < scheduler->count; ++i) {
-    if (scheduler->priorities[i] == priority) {
-      count += 1u;
-    }
+  bucket = priority_bucket_index(priority);
+  if (bucket < 0) {
+    return 0u;
   }
-  return count;
+  return scheduler->priority_counts[(size_t)bucket];
 }
 
 static void refill_credits(aegis_scheduler_t *scheduler) {
   size_t i;
+  scheduler->runnable_credit_count = 0u;
   for (i = 0; i < scheduler->count; ++i) {
     uint8_t base = normalize_priority(scheduler->priorities[i]);
     /* Aging boost helps long-waiting low-priority tasks avoid starvation. */
@@ -356,6 +355,9 @@ static void refill_credits(aegis_scheduler_t *scheduler) {
       base = (uint8_t)(base + boost);
     }
     scheduler->credits[i] = base;
+    if (base > 0u) {
+      scheduler->runnable_credit_count += 1u;
+    }
   }
 }
 
@@ -432,6 +434,7 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->turbo_autotune_adjustments = 0u;
   scheduler->turbo_last_pid = 0u;
   scheduler->admission_profile_id = AEGIS_SCHED_ADMISSION_PROFILE_CUSTOM;
+  scheduler->runnable_credit_count = 0u;
   scheduler->reason_switch_window_head = 0;
   scheduler->reason_switch_window_count = 0;
   for (i = 0; i < AEGIS_SCHEDULER_CAPACITY; ++i) {
@@ -445,6 +448,7 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   }
   for (i = 0; i < 4u; ++i) {
     scheduler->admission_limits[i] = 0u;
+    scheduler->priority_counts[i] = 0u;
     scheduler->admission_drops[i] = 0u;
   }
   for (i = 0; i < 5u; ++i) {
@@ -508,6 +512,10 @@ int aegis_scheduler_add_with_priority(aegis_scheduler_t *scheduler, uint32_t pro
   scheduler->enqueued_tick[scheduler->count] = scheduler->scheduler_ticks;
   scheduler->wait_ticks_total[scheduler->count] = 0;
   scheduler->last_wait_latency[scheduler->count] = 0;
+  scheduler->priority_counts[(size_t)bucket] += 1u;
+  if (scheduler->credits[scheduler->count] > 0u) {
+    scheduler->runnable_credit_count += 1u;
+  }
   scheduler->count += 1;
   if (scheduler->count > scheduler->high_watermark) {
     scheduler->high_watermark = scheduler->count;
@@ -518,8 +526,23 @@ int aegis_scheduler_add_with_priority(aegis_scheduler_t *scheduler, uint32_t pro
 int aegis_scheduler_remove(aegis_scheduler_t *scheduler, uint32_t process_id) {
   size_t idx = 0;
   size_t i;
+  uint8_t removed_priority;
+  int removed_bucket;
+  uint8_t removed_credit;
+  if (scheduler == 0) {
+    return -1;
+  }
   if (!find_index(scheduler, process_id, &idx)) {
     return -1;
+  }
+  removed_priority = scheduler->priorities[idx];
+  removed_bucket = priority_bucket_index(removed_priority);
+  removed_credit = scheduler->credits[idx];
+  if (removed_bucket >= 0 && scheduler->priority_counts[(size_t)removed_bucket] > 0u) {
+    scheduler->priority_counts[(size_t)removed_bucket] -= 1u;
+  }
+  if (removed_credit > 0u && scheduler->runnable_credit_count > 0u) {
+    scheduler->runnable_credit_count -= 1u;
   }
   if (scheduler->current_pid == process_id) {
     scheduler->current_pid = 0;
@@ -550,34 +573,49 @@ int aegis_scheduler_remove(aegis_scheduler_t *scheduler, uint32_t process_id) {
 
 int aegis_scheduler_set_priority(aegis_scheduler_t *scheduler, uint32_t process_id, uint8_t priority) {
   size_t idx = 0;
+  uint8_t old_priority;
+  uint8_t new_priority;
+  int old_bucket;
+  int new_bucket;
   if (scheduler == 0 || !find_index(scheduler, process_id, &idx)) {
     return -1;
   }
-  scheduler->priorities[idx] = normalize_priority(priority);
+  old_priority = scheduler->priorities[idx];
+  new_priority = normalize_priority(priority);
+  old_bucket = priority_bucket_index(old_priority);
+  new_bucket = priority_bucket_index(new_priority);
+  if (old_bucket >= 0 && scheduler->priority_counts[(size_t)old_bucket] > 0u) {
+    scheduler->priority_counts[(size_t)old_bucket] -= 1u;
+  }
+  if (new_bucket >= 0) {
+    scheduler->priority_counts[(size_t)new_bucket] += 1u;
+  }
+  scheduler->priorities[idx] = new_priority;
+  if (scheduler->credits[idx] > 0u && scheduler->runnable_credit_count > 0u) {
+    scheduler->runnable_credit_count -= 1u;
+  }
   scheduler->credits[idx] = scheduler->priorities[idx];
+  if (scheduler->credits[idx] > 0u) {
+    scheduler->runnable_credit_count += 1u;
+  }
   return 0;
 }
 
 int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
   size_t attempts;
-  int any_credit = 0;
-  size_t i;
   size_t chosen_idx = 0u;
   if (scheduler == 0 || process_id == 0 || scheduler->count == 0) {
     return -1;
   }
-  for (i = 0; i < scheduler->count; ++i) {
-    if (scheduler->credits[i] > 0) {
-      any_credit = 1;
-      break;
-    }
-  }
-  if (!any_credit) {
+  if (scheduler->runnable_credit_count == 0u) {
     refill_credits(scheduler);
   }
   if (scheduler->dispatch_strategy == AEGIS_SCHED_STRATEGY_TURBO &&
       scheduler_pick_turbo_index(scheduler, &chosen_idx)) {
     scheduler->credits[chosen_idx] -= 1;
+    if (scheduler->credits[chosen_idx] == 0u && scheduler->runnable_credit_count > 0u) {
+      scheduler->runnable_credit_count -= 1u;
+    }
     scheduler->last_wait_latency[chosen_idx] =
         scheduler->scheduler_ticks - scheduler->enqueued_tick[chosen_idx];
     scheduler->wait_ticks_total[chosen_idx] += scheduler->last_wait_latency[chosen_idx];
@@ -595,6 +633,9 @@ int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
       continue;
     }
     scheduler->credits[idx] -= 1;
+    if (scheduler->credits[idx] == 0u && scheduler->runnable_credit_count > 0u) {
+      scheduler->runnable_credit_count -= 1u;
+    }
     scheduler->last_wait_latency[idx] = scheduler->scheduler_ticks - scheduler->enqueued_tick[idx];
     scheduler->wait_ticks_total[idx] += scheduler->last_wait_latency[idx];
     scheduler->dispatch_counts[idx] += 1;
@@ -651,7 +692,9 @@ void aegis_scheduler_reset_metrics(aegis_scheduler_t *scheduler) {
     scheduler->wait_ticks_total[i] = 0;
     scheduler->last_wait_latency[i] = 0;
     scheduler->enqueued_tick[i] = scheduler->scheduler_ticks;
+    scheduler->credits[i] = normalize_priority(scheduler->priorities[i]);
   }
+  scheduler->runnable_credit_count = (uint16_t)scheduler->count;
   for (i = 0; i < 5u; ++i) {
     scheduler->reason_switch_counts[i] = 0;
   }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -466,6 +466,28 @@ static int test_scheduler_admission_profile_name_resolver(void) {
   return 0;
 }
 
+static int test_scheduler_priority_count_tracking_after_reprioritize(void) {
+  aegis_scheduler_t scheduler;
+  char json[512];
+  aegis_scheduler_init(&scheduler);
+  if (aegis_scheduler_add_with_priority(&scheduler, 9701u, AEGIS_PRIORITY_HIGH) != 0 ||
+      aegis_scheduler_add_with_priority(&scheduler, 9702u, AEGIS_PRIORITY_NORMAL) != 0 ||
+      aegis_scheduler_add_with_priority(&scheduler, 9703u, AEGIS_PRIORITY_LOW) != 0) {
+    fprintf(stderr, "priority count tracking add failed\n");
+    return 1;
+  }
+  if (aegis_scheduler_set_priority(&scheduler, 9702u, AEGIS_PRIORITY_HIGH) != 0) {
+    fprintf(stderr, "priority count tracking reprioritize failed\n");
+    return 1;
+  }
+  if (aegis_scheduler_admission_snapshot_json(&scheduler, json, sizeof(json)) <= 0 ||
+      strstr(json, "\"counts\":{\"high\":2,\"normal\":0,\"low\":1}") == 0) {
+    fprintf(stderr, "priority count tracking snapshot mismatch: %s\n", json);
+    return 1;
+  }
+  return 0;
+}
+
 static int test_namespace_isolation_simulator(void) {
   aegis_namespace_table_t table;
   uint32_t ns_a = 0u;
@@ -1464,6 +1486,9 @@ int main(void) {
     return 1;
   }
   if (test_scheduler_admission_profile_name_resolver() != 0) {
+    return 1;
+  }
+  if (test_scheduler_priority_count_tracking_after_reprioritize() != 0) {
     return 1;
   }
   if (test_namespace_isolation_simulator() != 0) {


### PR DESCRIPTION
## Summary
- optimize scheduler hot path with live priority_counts and unnable_credit_count bookkeeping
- remove repeated O(n) scans from admission membership lookup and credit-availability checks
- keep counters synchronized across add/remove/reprioritize/refill/reset paths
- add kernel simulation regression test for reprioritize count tracking
- document scheduler hot-path optimization in project docs

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #152