### PR TITLE
feat: issue #154 adaptive scheduler quantum autotuner

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This repository contains:
 - Service restart budget supervisor with health-probe and metrics-export JSON endpoints for ops dashboards.
 - Kernel checkpoint journal persistence + replay path for crash-recovery boot restore.
 - Scheduler hot-path optimization via live priority/runnable-credit counters for faster dispatch bookkeeping.
+- Adaptive scheduler quantum autotuner for improved latency vs switch-overhead balance under load.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -13,6 +13,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - includes payload-fit guard helper for max-frame enforcement.
 - `aegis_scheduler_t`: weighted round-robin scheduler with priority-aware dispatch.
   - optimized hot-path dispatch bookkeeping with live `priority_counts` and `runnable_credit_count` counters to reduce full-queue scans.
+  - includes adaptive quantum autotuner to rebalance tail-latency and context-switch pressure automatically.
   - includes optional `turbo` dispatch strategy that scores queue entries by priority + wait time for lower tail latency.
   - turbo mode retains fairness pressure by debiasing over-dispatched processes and preserving credit-based limits.
   - turbo mode includes adaptive weight autotuning to rebalance `priority` vs `wait` based on live latency telemetry.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -62,6 +62,13 @@ typedef struct {
   uint32_t reason_switch_window_count;
   uint32_t quantum_ticks;
   uint32_t quantum_remaining;
+  uint8_t quantum_autotune_enabled;
+  uint32_t quantum_autotune_interval_ticks;
+  uint32_t quantum_autotune_min_ticks;
+  uint32_t quantum_autotune_max_ticks;
+  uint64_t quantum_autotune_last_tick;
+  uint64_t quantum_autotune_last_switch_total;
+  uint64_t quantum_autotune_adjustments;
   uint8_t dispatch_strategy;
   uint8_t turbo_wait_weight;
   uint8_t turbo_priority_weight;
@@ -337,6 +344,14 @@ int aegis_scheduler_dispatch_count_for(const aegis_scheduler_t *scheduler, uint3
                                        uint32_t *dispatch_count);
 void aegis_scheduler_reset_metrics(aegis_scheduler_t *scheduler);
 void aegis_scheduler_set_quantum(aegis_scheduler_t *scheduler, uint32_t quantum_ticks);
+void aegis_scheduler_enable_quantum_autotune(aegis_scheduler_t *scheduler,
+                                             uint8_t enabled,
+                                             uint32_t interval_ticks,
+                                             uint32_t min_ticks,
+                                             uint32_t max_ticks);
+int aegis_scheduler_quantum_autotune_state_json(const aegis_scheduler_t *scheduler,
+                                                char *out,
+                                                size_t out_size);
 void aegis_scheduler_enable_turbo(aegis_scheduler_t *scheduler, uint8_t enabled);
 void aegis_scheduler_set_turbo_weights(aegis_scheduler_t *scheduler,
                                        uint8_t wait_weight,

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -411,6 +411,16 @@ static int scheduler_pick_turbo_index(const aegis_scheduler_t *scheduler, size_t
   return 1;
 }
 
+static uint64_t scheduler_total_switches(const aegis_scheduler_t *scheduler) {
+  if (scheduler == 0) {
+    return 0u;
+  }
+  return scheduler->reason_switch_counts[AEGIS_SWITCH_PROCESS_START] +
+         scheduler->reason_switch_counts[AEGIS_SWITCH_QUANTUM_EXPIRED] +
+         scheduler->reason_switch_counts[AEGIS_SWITCH_PROCESS_EXIT] +
+         scheduler->reason_switch_counts[AEGIS_SWITCH_MANUAL_YIELD];
+}
+
 void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   size_t i;
   if (scheduler == 0) {
@@ -425,6 +435,13 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->pending_switch_reason = AEGIS_SWITCH_PROCESS_START;
   scheduler->quantum_ticks = 3;
   scheduler->quantum_remaining = 0;
+  scheduler->quantum_autotune_enabled = 1u;
+  scheduler->quantum_autotune_interval_ticks = 64u;
+  scheduler->quantum_autotune_min_ticks = 1u;
+  scheduler->quantum_autotune_max_ticks = 6u;
+  scheduler->quantum_autotune_last_tick = 0u;
+  scheduler->quantum_autotune_last_switch_total = 0u;
+  scheduler->quantum_autotune_adjustments = 0u;
   scheduler->dispatch_strategy = AEGIS_SCHED_STRATEGY_ROUND_ROBIN;
   scheduler->turbo_wait_weight = 2u;
   scheduler->turbo_priority_weight = 4u;
@@ -459,6 +476,9 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   }
   scheduler->turbo_autotune_last_tick = 0u;
   scheduler->turbo_last_pid = 0u;
+  scheduler->quantum_autotune_last_tick = 0u;
+  scheduler->quantum_autotune_last_switch_total = 0u;
+  scheduler->quantum_autotune_adjustments = 0u;
 }
 
 static int find_index(const aegis_scheduler_t *scheduler, uint32_t process_id, size_t *index) {
@@ -707,16 +727,50 @@ void aegis_scheduler_reset_metrics(aegis_scheduler_t *scheduler) {
     scheduler->reason_switch_window[i] = AEGIS_SWITCH_NONE;
   }
   scheduler->turbo_autotune_last_tick = scheduler->scheduler_ticks;
+  scheduler->quantum_autotune_last_tick = scheduler->scheduler_ticks;
+  scheduler->quantum_autotune_last_switch_total = 0u;
+  scheduler->quantum_autotune_adjustments = 0u;
 }
 
 void aegis_scheduler_set_quantum(aegis_scheduler_t *scheduler, uint32_t quantum_ticks) {
   if (scheduler == 0 || quantum_ticks == 0) {
     return;
   }
+  if (scheduler->quantum_autotune_min_ticks > 0u &&
+      quantum_ticks < scheduler->quantum_autotune_min_ticks) {
+    quantum_ticks = scheduler->quantum_autotune_min_ticks;
+  }
+  if (scheduler->quantum_autotune_max_ticks > 0u &&
+      quantum_ticks > scheduler->quantum_autotune_max_ticks) {
+    quantum_ticks = scheduler->quantum_autotune_max_ticks;
+  }
   scheduler->quantum_ticks = quantum_ticks;
   if (scheduler->quantum_remaining > quantum_ticks) {
     scheduler->quantum_remaining = quantum_ticks;
   }
+}
+
+void aegis_scheduler_enable_quantum_autotune(aegis_scheduler_t *scheduler,
+                                             uint8_t enabled,
+                                             uint32_t interval_ticks,
+                                             uint32_t min_ticks,
+                                             uint32_t max_ticks) {
+  if (scheduler == 0) {
+    return;
+  }
+  scheduler->quantum_autotune_enabled = enabled != 0u ? 1u : 0u;
+  if (interval_ticks > 0u) {
+    scheduler->quantum_autotune_interval_ticks = interval_ticks;
+  }
+  if (min_ticks == 0u) {
+    min_ticks = 1u;
+  }
+  if (max_ticks == 0u || max_ticks < min_ticks) {
+    max_ticks = min_ticks;
+  }
+  scheduler->quantum_autotune_min_ticks = min_ticks;
+  scheduler->quantum_autotune_max_ticks = max_ticks;
+  aegis_scheduler_set_quantum(scheduler, scheduler->quantum_ticks);
 }
 
 void aegis_scheduler_enable_turbo(aegis_scheduler_t *scheduler, uint8_t enabled) {
@@ -793,6 +847,44 @@ static void aegis_scheduler_turbo_autotune_step(aegis_scheduler_t *scheduler) {
   }
 }
 
+static void aegis_scheduler_quantum_autotune_step(aegis_scheduler_t *scheduler) {
+  uint64_t switch_total;
+  uint64_t switch_delta;
+  uint64_t elapsed_ticks;
+  uint64_t switch_pressure_bps;
+  aegis_scheduler_wait_report_t report;
+  if (scheduler == 0 || scheduler->quantum_autotune_enabled == 0u || scheduler->count == 0u) {
+    return;
+  }
+  if (scheduler->quantum_autotune_interval_ticks == 0u) {
+    scheduler->quantum_autotune_interval_ticks = 64u;
+  }
+  if (scheduler->scheduler_ticks - scheduler->quantum_autotune_last_tick <
+      scheduler->quantum_autotune_interval_ticks) {
+    return;
+  }
+  elapsed_ticks = scheduler->scheduler_ticks - scheduler->quantum_autotune_last_tick;
+  if (elapsed_ticks == 0u || aegis_scheduler_wait_report(scheduler, &report) != 0) {
+    return;
+  }
+  switch_total = scheduler_total_switches(scheduler);
+  switch_delta = switch_total - scheduler->quantum_autotune_last_switch_total;
+  switch_pressure_bps = (switch_delta * 10000u) / elapsed_ticks;
+  if (report.p95_wait_ticks > 8u && scheduler->quantum_ticks > scheduler->quantum_autotune_min_ticks) {
+    scheduler->quantum_ticks -= 1u;
+    if (scheduler->quantum_remaining > scheduler->quantum_ticks) {
+      scheduler->quantum_remaining = scheduler->quantum_ticks;
+    }
+    scheduler->quantum_autotune_adjustments += 1u;
+  } else if (report.p95_wait_ticks <= 2u && switch_pressure_bps > 7000u &&
+             scheduler->quantum_ticks < scheduler->quantum_autotune_max_ticks) {
+    scheduler->quantum_ticks += 1u;
+    scheduler->quantum_autotune_adjustments += 1u;
+  }
+  scheduler->quantum_autotune_last_tick = scheduler->scheduler_ticks;
+  scheduler->quantum_autotune_last_switch_total = switch_total;
+}
+
 int aegis_scheduler_turbo_state_json(const aegis_scheduler_t *scheduler, char *out, size_t out_size) {
   int written;
   if (scheduler == 0 || out == 0 || out_size == 0u) {
@@ -811,6 +903,30 @@ int aegis_scheduler_turbo_state_json(const aegis_scheduler_t *scheduler, char *o
                      (unsigned int)scheduler->turbo_autotune_interval_ticks,
                      (unsigned long long)scheduler->turbo_autotune_adjustments,
                      scheduler->turbo_last_pid);
+  if (written < 0 || (size_t)written >= out_size) {
+    return -1;
+  }
+  return written;
+}
+
+int aegis_scheduler_quantum_autotune_state_json(const aegis_scheduler_t *scheduler,
+                                                char *out,
+                                                size_t out_size) {
+  int written;
+  if (scheduler == 0 || out == 0 || out_size == 0u) {
+    return -1;
+  }
+  written = snprintf(out,
+                     out_size,
+                     "{\"schema_version\":1,\"quantum_ticks\":%u,\"quantum_autotune_enabled\":%u,"
+                     "\"quantum_autotune_interval_ticks\":%u,\"quantum_autotune_min_ticks\":%u,"
+                     "\"quantum_autotune_max_ticks\":%u,\"quantum_autotune_adjustments\":%llu}",
+                     (unsigned int)scheduler->quantum_ticks,
+                     (unsigned int)scheduler->quantum_autotune_enabled,
+                     (unsigned int)scheduler->quantum_autotune_interval_ticks,
+                     (unsigned int)scheduler->quantum_autotune_min_ticks,
+                     (unsigned int)scheduler->quantum_autotune_max_ticks,
+                     (unsigned long long)scheduler->quantum_autotune_adjustments);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }
@@ -863,6 +979,7 @@ int aegis_scheduler_on_tick_ex(aegis_scheduler_t *scheduler, uint32_t *running_p
     }
   }
   aegis_scheduler_turbo_autotune_step(scheduler);
+  aegis_scheduler_quantum_autotune_step(scheduler);
   *running_pid = scheduler->current_pid;
   return 0;
 }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -314,6 +314,45 @@ static int test_scheduler_turbo_autotuner_adjusts_weights(void) {
   return 0;
 }
 
+static int test_scheduler_quantum_autotuner_adjusts_quantum(void) {
+  aegis_scheduler_t scheduler;
+  uint32_t pid = 0u;
+  uint8_t switched = 0u;
+  char json[256];
+  int i;
+  aegis_scheduler_init(&scheduler);
+  aegis_scheduler_enable_quantum_autotune(&scheduler, 1u, 8u, 1u, 4u);
+  aegis_scheduler_set_quantum(&scheduler, 4u);
+  if (aegis_scheduler_add_with_priority(&scheduler, 4101u, AEGIS_PRIORITY_HIGH) != 0 ||
+      aegis_scheduler_add_with_priority(&scheduler, 4102u, AEGIS_PRIORITY_NORMAL) != 0 ||
+      aegis_scheduler_add_with_priority(&scheduler, 4103u, AEGIS_PRIORITY_LOW) != 0) {
+    fprintf(stderr, "quantum autotuner setup add failed\n");
+    return 1;
+  }
+  for (i = 0; i < 96; ++i) {
+    if (aegis_scheduler_on_tick(&scheduler, &pid, &switched) != 0) {
+      fprintf(stderr, "quantum autotuner tick failed\n");
+      return 1;
+    }
+  }
+  if (scheduler.quantum_autotune_adjustments == 0u) {
+    fprintf(stderr, "quantum autotuner expected at least one adjustment\n");
+    return 1;
+  }
+  if (scheduler.quantum_ticks < 1u || scheduler.quantum_ticks > 4u) {
+    fprintf(stderr, "quantum autotuner quantum out of range: %u\n", scheduler.quantum_ticks);
+    return 1;
+  }
+  if (aegis_scheduler_quantum_autotune_state_json(&scheduler, json, sizeof(json)) <= 0 ||
+      strstr(json, "\"schema_version\":1") == 0 ||
+      strstr(json, "\"quantum_autotune_adjustments\":") == 0 ||
+      strstr(json, "\"quantum_autotune_interval_ticks\":8") == 0) {
+    fprintf(stderr, "quantum autotuner state json mismatch: %s\n", json);
+    return 1;
+  }
+  return 0;
+}
+
 static int test_scheduler_aging_boost_fairness(void) {
   aegis_scheduler_t scheduler;
   uint32_t pid = 0;
@@ -1474,6 +1513,9 @@ int main(void) {
     return 1;
   }
   if (test_scheduler_turbo_autotuner_adjusts_weights() != 0) {
+    return 1;
+  }
+  if (test_scheduler_quantum_autotuner_adjusts_quantum() != 0) {
     return 1;
   }
   if (test_scheduler_aging_boost_fairness() != 0) {


### PR DESCRIPTION
## Summary
- add adaptive scheduler quantum autotuner with bounded min/max quantum policy
- tune quantum using live p95 wait latency and context-switch pressure signals
- expose quantum autotune controls and JSON state endpoint
- extend kernel tests with quantum autotuner adjustment/state coverage
- update docs for new scheduler optimization capability

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #154