### PR TITLE
feat: issue #159 syscall gate decision-cache fast path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This repository contains:
 - Scheduler admission control primitives with per-priority limits, drop counters, and JSON snapshots.
 - Namespace isolation simulator with local/global PID translation and visibility checks.
 - Atomic update rollback-index monotonic guard store with tamper-checked persistence.
-- Syscall capability gate matrix scaffold with enforcement counters and JSON snapshot.
+- Syscall capability gate matrix with decision-cache fast path, enforcement counters, and JSON snapshot.
 - IPC channel quota/backpressure simulator with inflight accounting and drop metrics.
 - Memory zone accounting with reclaim hooks and low-memory deny telemetry.
 - Update release channel pinning policy with downgrade rejection guardrails.

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -39,3 +39,6 @@ Kernel direction, interfaces, and implementation notes live here.
   - supports checkpoint restore with epoch verification and failure counters.
   - exposes snapshot JSON endpoint with entry-level checkpoint metadata.
   - supports disk-backed journal save and boot-time replay for crash recovery.
+- `aegis_syscall_gate_matrix_t`: syscall capability enforcement matrix.
+  - includes decision-cache fast path for hot process/syscall pairs.
+  - preserves deny-reason counters while reducing repeated linear scans.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -12,6 +12,7 @@
 #define AEGIS_NAMESPACE_PROCESS_CAPACITY 256u
 #define AEGIS_SYSCALL_GATE_CAPACITY 128u
 #define AEGIS_SYSCALL_RULE_CAPACITY 64u
+#define AEGIS_SYSCALL_DECISION_CACHE_CAPACITY 64u
 #define AEGIS_IPC_CHANNEL_CAPACITY 64u
 #define AEGIS_MEMORY_ZONE_CAPACITY 16u
 #define AEGIS_PROCESS_CHECKPOINT_CAPACITY 128u
@@ -176,13 +177,27 @@ typedef struct {
 } aegis_syscall_rule_t;
 
 typedef struct {
+  uint32_t process_id;
+  uint16_t syscall_id;
+  uint8_t policy_gate_allowed;
+  uint8_t allowed;
+  uint8_t deny_reason;
+  uint32_t generation;
+  uint8_t active;
+} aegis_syscall_decision_cache_entry_t;
+
+typedef struct {
   aegis_syscall_process_caps_t process_caps[AEGIS_SYSCALL_GATE_CAPACITY];
   aegis_syscall_rule_t rules[AEGIS_SYSCALL_RULE_CAPACITY];
+  aegis_syscall_decision_cache_entry_t decision_cache[AEGIS_SYSCALL_DECISION_CACHE_CAPACITY];
   uint64_t allow_count;
   uint64_t deny_missing_rule_count;
   uint64_t deny_missing_process_count;
   uint64_t deny_missing_capability_count;
   uint64_t deny_policy_gate_count;
+  uint64_t decision_cache_hits;
+  uint64_t decision_cache_misses;
+  uint32_t decision_cache_generation;
 } aegis_syscall_gate_matrix_t;
 
 typedef struct {

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -1938,6 +1938,42 @@ static int syscall_rule_find_index(const aegis_syscall_gate_matrix_t *matrix,
   return 0;
 }
 
+static uint8_t syscall_gate_decision_reason(const aegis_syscall_gate_matrix_t *matrix,
+                                            uint32_t process_id,
+                                            uint16_t syscall_id,
+                                            uint8_t policy_gate_allowed) {
+  size_t rule_index = 0u;
+  size_t proc_index = 0u;
+  uint32_t required_caps = 0u;
+  if (!syscall_rule_find_index(matrix, syscall_id, &rule_index)) {
+    return 1u;
+  }
+  if (!syscall_process_find_index(matrix, process_id, &proc_index)) {
+    return 2u;
+  }
+  if (matrix->rules[rule_index].policy_gate_required != 0u && policy_gate_allowed == 0u) {
+    return 4u;
+  }
+  required_caps = matrix->rules[rule_index].required_capability;
+  if (required_caps != 0u &&
+      (matrix->process_caps[proc_index].granted_capabilities & required_caps) != required_caps) {
+    return 3u;
+  }
+  return 0u;
+}
+
+static size_t syscall_gate_cache_index(uint32_t process_id, uint16_t syscall_id, uint8_t policy_gate_allowed) {
+  uint32_t mix = process_id ^ ((uint32_t)syscall_id << 8) ^ ((uint32_t)policy_gate_allowed << 1);
+  return (size_t)(mix % AEGIS_SYSCALL_DECISION_CACHE_CAPACITY);
+}
+
+static void syscall_gate_cache_invalidate(aegis_syscall_gate_matrix_t *matrix) {
+  if (matrix == 0) {
+    return;
+  }
+  matrix->decision_cache_generation += 1u;
+}
+
 void aegis_syscall_gate_matrix_init(aegis_syscall_gate_matrix_t *matrix) {
   size_t i;
   if (matrix == 0) {
@@ -1955,11 +1991,23 @@ void aegis_syscall_gate_matrix_init(aegis_syscall_gate_matrix_t *matrix) {
     matrix->rules[i].policy_gate_required = 0u;
     matrix->rules[i].active = 0u;
   }
+  for (i = 0; i < AEGIS_SYSCALL_DECISION_CACHE_CAPACITY; ++i) {
+    matrix->decision_cache[i].process_id = 0u;
+    matrix->decision_cache[i].syscall_id = 0u;
+    matrix->decision_cache[i].policy_gate_allowed = 0u;
+    matrix->decision_cache[i].allowed = 0u;
+    matrix->decision_cache[i].deny_reason = 0u;
+    matrix->decision_cache[i].generation = 0u;
+    matrix->decision_cache[i].active = 0u;
+  }
   matrix->allow_count = 0u;
   matrix->deny_missing_rule_count = 0u;
   matrix->deny_missing_process_count = 0u;
   matrix->deny_missing_capability_count = 0u;
   matrix->deny_policy_gate_count = 0u;
+  matrix->decision_cache_hits = 0u;
+  matrix->decision_cache_misses = 0u;
+  matrix->decision_cache_generation = 1u;
 }
 
 int aegis_syscall_gate_set_process_caps(aegis_syscall_gate_matrix_t *matrix,
@@ -1972,6 +2020,7 @@ int aegis_syscall_gate_set_process_caps(aegis_syscall_gate_matrix_t *matrix,
   }
   if (syscall_process_find_index(matrix, process_id, &existing)) {
     matrix->process_caps[existing].granted_capabilities = granted_capabilities;
+    syscall_gate_cache_invalidate(matrix);
     return 0;
   }
   for (i = 0; i < AEGIS_SYSCALL_GATE_CAPACITY; ++i) {
@@ -1981,6 +2030,7 @@ int aegis_syscall_gate_set_process_caps(aegis_syscall_gate_matrix_t *matrix,
     matrix->process_caps[i].process_id = process_id;
     matrix->process_caps[i].granted_capabilities = granted_capabilities;
     matrix->process_caps[i].active = 1u;
+    syscall_gate_cache_invalidate(matrix);
     return 0;
   }
   return -1;
@@ -1997,6 +2047,7 @@ int aegis_syscall_gate_remove_process(aegis_syscall_gate_matrix_t *matrix, uint3
   matrix->process_caps[existing].active = 0u;
   matrix->process_caps[existing].process_id = 0u;
   matrix->process_caps[existing].granted_capabilities = 0u;
+  syscall_gate_cache_invalidate(matrix);
   return 0;
 }
 
@@ -2017,6 +2068,7 @@ int aegis_syscall_gate_set_rule(aegis_syscall_gate_matrix_t *matrix,
     matrix->rules[existing].syscall_class = syscall_class;
     matrix->rules[existing].required_capability = required_capability;
     matrix->rules[existing].policy_gate_required = policy_gate_required != 0u ? 1u : 0u;
+    syscall_gate_cache_invalidate(matrix);
     return 0;
   }
   for (i = 0; i < AEGIS_SYSCALL_RULE_CAPACITY; ++i) {
@@ -2028,6 +2080,7 @@ int aegis_syscall_gate_set_rule(aegis_syscall_gate_matrix_t *matrix,
     matrix->rules[i].required_capability = required_capability;
     matrix->rules[i].policy_gate_required = policy_gate_required != 0u ? 1u : 0u;
     matrix->rules[i].active = 1u;
+    syscall_gate_cache_invalidate(matrix);
     return 0;
   }
   return -1;
@@ -2038,29 +2091,60 @@ int aegis_syscall_gate_check(aegis_syscall_gate_matrix_t *matrix,
                              uint16_t syscall_id,
                              uint8_t policy_gate_allowed,
                              uint8_t *allowed_out) {
-  size_t rule_index = 0u;
-  size_t proc_index = 0u;
-  uint32_t required_caps;
+  size_t cache_idx = 0u;
+  aegis_syscall_decision_cache_entry_t *cache_entry = 0;
+  uint8_t reason = 0u;
   if (matrix == 0 || process_id == 0u || syscall_id == 0u || allowed_out == 0) {
     return -1;
   }
   *allowed_out = 0u;
-  if (!syscall_rule_find_index(matrix, syscall_id, &rule_index)) {
+  cache_idx = syscall_gate_cache_index(process_id, syscall_id, policy_gate_allowed != 0u ? 1u : 0u);
+  cache_entry = &matrix->decision_cache[cache_idx];
+  if (cache_entry->active != 0u &&
+      cache_entry->generation == matrix->decision_cache_generation &&
+      cache_entry->process_id == process_id &&
+      cache_entry->syscall_id == syscall_id &&
+      cache_entry->policy_gate_allowed == (policy_gate_allowed != 0u ? 1u : 0u)) {
+    matrix->decision_cache_hits += 1u;
+    if (cache_entry->allowed != 0u) {
+      matrix->allow_count += 1u;
+      *allowed_out = 1u;
+      return 1;
+    }
+    if (cache_entry->deny_reason == 1u) {
+      matrix->deny_missing_rule_count += 1u;
+    } else if (cache_entry->deny_reason == 2u) {
+      matrix->deny_missing_process_count += 1u;
+    } else if (cache_entry->deny_reason == 3u) {
+      matrix->deny_missing_capability_count += 1u;
+    } else if (cache_entry->deny_reason == 4u) {
+      matrix->deny_policy_gate_count += 1u;
+    }
+    return 0;
+  }
+  matrix->decision_cache_misses += 1u;
+  reason = syscall_gate_decision_reason(matrix, process_id, syscall_id, policy_gate_allowed);
+  cache_entry->process_id = process_id;
+  cache_entry->syscall_id = syscall_id;
+  cache_entry->policy_gate_allowed = policy_gate_allowed != 0u ? 1u : 0u;
+  cache_entry->allowed = reason == 0u ? 1u : 0u;
+  cache_entry->deny_reason = reason;
+  cache_entry->generation = matrix->decision_cache_generation;
+  cache_entry->active = 1u;
+  if (reason == 1u) {
     matrix->deny_missing_rule_count += 1u;
     return 0;
   }
-  if (!syscall_process_find_index(matrix, process_id, &proc_index)) {
+  if (reason == 2u) {
     matrix->deny_missing_process_count += 1u;
     return 0;
   }
-  if (matrix->rules[rule_index].policy_gate_required != 0u && policy_gate_allowed == 0u) {
-    matrix->deny_policy_gate_count += 1u;
+  if (reason == 3u) {
+    matrix->deny_missing_capability_count += 1u;
     return 0;
   }
-  required_caps = matrix->rules[rule_index].required_capability;
-  if (required_caps != 0u &&
-      (matrix->process_caps[proc_index].granted_capabilities & required_caps) != required_caps) {
-    matrix->deny_missing_capability_count += 1u;
+  if (reason == 4u) {
+    matrix->deny_policy_gate_count += 1u;
     return 0;
   }
   matrix->allow_count += 1u;
@@ -2084,12 +2168,15 @@ int aegis_syscall_gate_snapshot_json(const aegis_syscall_gate_matrix_t *matrix,
                      "{\"schema_version\":1,\"allow_count\":%llu,"
                      "\"deny_missing_rule_count\":%llu,\"deny_missing_process_count\":%llu,"
                      "\"deny_missing_capability_count\":%llu,\"deny_policy_gate_count\":%llu,"
+                     "\"decision_cache_hits\":%llu,\"decision_cache_misses\":%llu,"
                      "\"rules\":[",
                      (unsigned long long)matrix->allow_count,
                      (unsigned long long)matrix->deny_missing_rule_count,
                      (unsigned long long)matrix->deny_missing_process_count,
                      (unsigned long long)matrix->deny_missing_capability_count,
-                     (unsigned long long)matrix->deny_policy_gate_count);
+                     (unsigned long long)matrix->deny_policy_gate_count,
+                     (unsigned long long)matrix->decision_cache_hits,
+                     (unsigned long long)matrix->decision_cache_misses);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -669,13 +669,23 @@ static int test_syscall_capability_gate_matrix(void) {
     fprintf(stderr, "expected syscall deny for missing rule\n");
     return 1;
   }
+  if (aegis_syscall_gate_check(&matrix, 7001u, 100u, 1u, &allowed) != 1 || allowed != 1u) {
+    fprintf(stderr, "expected cached syscall 100 allow for process 7001\n");
+    return 1;
+  }
+  if (aegis_syscall_gate_check(&matrix, 7002u, 200u, 1u, &allowed) != 0 || allowed != 0u) {
+    fprintf(stderr, "expected cached syscall 200 deny missing capability\n");
+    return 1;
+  }
   if (aegis_syscall_gate_snapshot_json(&matrix, json, sizeof(json)) <= 0 ||
       strstr(json, "\"schema_version\":1") == 0 ||
-      strstr(json, "\"allow_count\":1") == 0 ||
+      strstr(json, "\"allow_count\":2") == 0 ||
       strstr(json, "\"deny_missing_rule_count\":1") == 0 ||
       strstr(json, "\"deny_missing_process_count\":1") == 0 ||
-      strstr(json, "\"deny_missing_capability_count\":1") == 0 ||
+      strstr(json, "\"deny_missing_capability_count\":2") == 0 ||
       strstr(json, "\"deny_policy_gate_count\":1") == 0 ||
+      strstr(json, "\"decision_cache_hits\":1") == 0 ||
+      strstr(json, "\"decision_cache_misses\":6") == 0 ||
       strstr(json, "\"syscall_id\":100") == 0 ||
       strstr(json, "\"process_id\":7001") == 0) {
     fprintf(stderr, "syscall gate snapshot mismatch: %s\n", json);


### PR DESCRIPTION
## Summary
- add syscall gate decision-cache fast path for hot process/syscall checks
- cache allow/deny plus deny-reason to preserve policy counters on cache hits
- invalidate cache generation on process-cap and rule mutations
- expose decision cache hit/miss counters in snapshot JSON
- extend kernel tests to verify cache-aware syscall gate behavior

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #159