### PR TITLE
feat: issues #161/#162 IPC+memory lookup-cache fast paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This repository contains:
 - Scheduler hot-path optimization via live priority/runnable-credit counters for faster dispatch bookkeeping.
 - Adaptive scheduler quantum autotuner for improved latency vs switch-overhead balance under load.
 - Scheduler admission/ready bitmaps + turbo candidate cache reuse for lower dispatch computation overhead.
+- IPC channel and memory zone lookup-cache fast paths to reduce hot-ID linear scan overhead.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -42,3 +42,6 @@ Kernel direction, interfaces, and implementation notes live here.
 - `aegis_syscall_gate_matrix_t`: syscall capability enforcement matrix.
   - includes decision-cache fast path for hot process/syscall pairs.
   - preserves deny-reason counters while reducing repeated linear scans.
+- `aegis_ipc_channel_table_t` and `aegis_memory_zone_table_t`:
+  - include lookup-cache fast paths for hot channel/zone IDs.
+  - expose lookup-cache hit/miss telemetry in JSON snapshots.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -215,6 +215,11 @@ typedef struct {
   uint64_t total_accepted_messages;
   uint64_t total_dropped_messages;
   uint64_t total_backpressure_events;
+  uint32_t lookup_cache_channel_id;
+  uint16_t lookup_cache_index;
+  uint8_t lookup_cache_valid;
+  uint64_t lookup_cache_hits;
+  uint64_t lookup_cache_misses;
 } aegis_ipc_channel_table_t;
 
 typedef enum {
@@ -243,6 +248,11 @@ typedef struct {
   uint64_t total_used_bytes;
   uint64_t denied_charges;
   uint64_t reclaim_events;
+  uint32_t lookup_cache_zone_id;
+  uint16_t lookup_cache_index;
+  uint8_t lookup_cache_valid;
+  uint64_t lookup_cache_hits;
+  uint64_t lookup_cache_misses;
 } aegis_memory_zone_table_t;
 
 typedef enum {

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -2238,10 +2238,23 @@ static int ipc_channel_find_index(const aegis_ipc_channel_table_t *table,
   if (table == 0 || index_out == 0 || channel_id == 0u) {
     return 0;
   }
+  if (table->lookup_cache_valid != 0u &&
+      table->lookup_cache_channel_id == channel_id &&
+      table->lookup_cache_index < AEGIS_IPC_CHANNEL_CAPACITY &&
+      table->channels[table->lookup_cache_index].active != 0u &&
+      table->channels[table->lookup_cache_index].channel_id == channel_id) {
+    *index_out = table->lookup_cache_index;
+    ((aegis_ipc_channel_table_t *)table)->lookup_cache_hits += 1u;
+    return 1;
+  }
+  ((aegis_ipc_channel_table_t *)table)->lookup_cache_misses += 1u;
   for (i = 0; i < AEGIS_IPC_CHANNEL_CAPACITY; ++i) {
     if (table->channels[i].active != 0u &&
         table->channels[i].channel_id == channel_id) {
       *index_out = i;
+      ((aegis_ipc_channel_table_t *)table)->lookup_cache_valid = 1u;
+      ((aegis_ipc_channel_table_t *)table)->lookup_cache_channel_id = channel_id;
+      ((aegis_ipc_channel_table_t *)table)->lookup_cache_index = (uint16_t)i;
       return 1;
     }
   }
@@ -2265,6 +2278,11 @@ void aegis_ipc_channel_table_init(aegis_ipc_channel_table_t *table) {
   table->total_accepted_messages = 0u;
   table->total_dropped_messages = 0u;
   table->total_backpressure_events = 0u;
+  table->lookup_cache_channel_id = 0u;
+  table->lookup_cache_index = 0u;
+  table->lookup_cache_valid = 0u;
+  table->lookup_cache_hits = 0u;
+  table->lookup_cache_misses = 0u;
 }
 
 int aegis_ipc_channel_configure(aegis_ipc_channel_table_t *table,
@@ -2280,6 +2298,9 @@ int aegis_ipc_channel_configure(aegis_ipc_channel_table_t *table,
     if (table->channels[existing].inflight_bytes > quota_bytes) {
       table->channels[existing].inflight_bytes = quota_bytes;
     }
+    table->lookup_cache_valid = 1u;
+    table->lookup_cache_channel_id = channel_id;
+    table->lookup_cache_index = (uint16_t)existing;
     return 0;
   }
   for (i = 0; i < AEGIS_IPC_CHANNEL_CAPACITY; ++i) {
@@ -2293,6 +2314,9 @@ int aegis_ipc_channel_configure(aegis_ipc_channel_table_t *table,
     table->channels[i].dropped_messages = 0u;
     table->channels[i].backpressure_events = 0u;
     table->channels[i].active = 1u;
+    table->lookup_cache_valid = 1u;
+    table->lookup_cache_channel_id = channel_id;
+    table->lookup_cache_index = (uint16_t)i;
     return 0;
   }
   return -1;
@@ -2358,10 +2382,13 @@ int aegis_ipc_channel_snapshot_json(const aegis_ipc_channel_table_t *table,
                      out_size,
                      "{\"schema_version\":1,\"total_accepted_messages\":%llu,"
                      "\"total_dropped_messages\":%llu,\"total_backpressure_events\":%llu,"
+                     "\"lookup_cache_hits\":%llu,\"lookup_cache_misses\":%llu,"
                      "\"channels\":[",
                      (unsigned long long)table->total_accepted_messages,
                      (unsigned long long)table->total_dropped_messages,
-                     (unsigned long long)table->total_backpressure_events);
+                     (unsigned long long)table->total_backpressure_events,
+                     (unsigned long long)table->lookup_cache_hits,
+                     (unsigned long long)table->lookup_cache_misses);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }
@@ -2404,9 +2431,22 @@ static int memory_zone_find_index(const aegis_memory_zone_table_t *table,
   if (table == 0 || zone_id == 0u || index_out == 0) {
     return 0;
   }
+  if (table->lookup_cache_valid != 0u &&
+      table->lookup_cache_zone_id == zone_id &&
+      table->lookup_cache_index < AEGIS_MEMORY_ZONE_CAPACITY &&
+      table->zones[table->lookup_cache_index].active != 0u &&
+      table->zones[table->lookup_cache_index].zone_id == zone_id) {
+    *index_out = table->lookup_cache_index;
+    ((aegis_memory_zone_table_t *)table)->lookup_cache_hits += 1u;
+    return 1;
+  }
+  ((aegis_memory_zone_table_t *)table)->lookup_cache_misses += 1u;
   for (i = 0; i < AEGIS_MEMORY_ZONE_CAPACITY; ++i) {
     if (table->zones[i].active != 0u && table->zones[i].zone_id == zone_id) {
       *index_out = i;
+      ((aegis_memory_zone_table_t *)table)->lookup_cache_valid = 1u;
+      ((aegis_memory_zone_table_t *)table)->lookup_cache_zone_id = zone_id;
+      ((aegis_memory_zone_table_t *)table)->lookup_cache_index = (uint16_t)i;
       return 1;
     }
   }
@@ -2422,6 +2462,11 @@ void aegis_memory_zone_table_init(aegis_memory_zone_table_t *table) {
   table->total_used_bytes = 0u;
   table->denied_charges = 0u;
   table->reclaim_events = 0u;
+  table->lookup_cache_zone_id = 0u;
+  table->lookup_cache_index = 0u;
+  table->lookup_cache_valid = 0u;
+  table->lookup_cache_hits = 0u;
+  table->lookup_cache_misses = 0u;
   for (i = 0; i < AEGIS_MEMORY_ZONE_CAPACITY; ++i) {
     table->zones[i].zone_id = 0u;
     table->zones[i].zone_kind = 0u;
@@ -2460,6 +2505,9 @@ int aegis_memory_zone_configure(aegis_memory_zone_table_t *table,
     if (table->zones[idx].used_bytes > budget_bytes) {
       table->zones[idx].used_bytes = budget_bytes;
     }
+    table->lookup_cache_valid = 1u;
+    table->lookup_cache_zone_id = zone_id;
+    table->lookup_cache_index = (uint16_t)idx;
     return 0;
   }
   for (i = 0; i < AEGIS_MEMORY_ZONE_CAPACITY; ++i) {
@@ -2477,6 +2525,9 @@ int aegis_memory_zone_configure(aegis_memory_zone_table_t *table,
     table->zones[i].reclaim_hook_enabled = 0u;
     table->zones[i].active = 1u;
     table->total_budget_bytes += budget_bytes;
+    table->lookup_cache_valid = 1u;
+    table->lookup_cache_zone_id = zone_id;
+    table->lookup_cache_index = (uint16_t)i;
     return 0;
   }
   return -1;
@@ -2587,11 +2638,14 @@ int aegis_memory_zone_snapshot_json(const aegis_memory_zone_table_t *table,
   written = snprintf(out,
                      out_size,
                      "{\"schema_version\":1,\"total_budget_bytes\":%llu,\"total_used_bytes\":%llu,"
-                     "\"denied_charges\":%llu,\"reclaim_events\":%llu,\"zones\":[",
+                     "\"denied_charges\":%llu,\"reclaim_events\":%llu,"
+                     "\"lookup_cache_hits\":%llu,\"lookup_cache_misses\":%llu,\"zones\":[",
                      (unsigned long long)table->total_budget_bytes,
                      (unsigned long long)table->total_used_bytes,
                      (unsigned long long)table->denied_charges,
-                     (unsigned long long)table->reclaim_events);
+                     (unsigned long long)table->reclaim_events,
+                     (unsigned long long)table->lookup_cache_hits,
+                     (unsigned long long)table->lookup_cache_misses);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -730,6 +730,10 @@ static int test_ipc_channel_quota_and_backpressure(void) {
     fprintf(stderr, "ipc reserve send should recover after drain\n");
     return 1;
   }
+  if (aegis_ipc_channel_drain(&table, 42u, 10u) != 0) {
+    fprintf(stderr, "ipc drain hot-channel cache path failed\n");
+    return 1;
+  }
   if (aegis_ipc_channel_reserve_send(&table, 999u, 10u, &accepted) >= 0) {
     fprintf(stderr, "ipc reserve send should fail for unknown channel\n");
     return 1;
@@ -739,8 +743,10 @@ static int test_ipc_channel_quota_and_backpressure(void) {
       strstr(json, "\"total_accepted_messages\":2") == 0 ||
       strstr(json, "\"total_dropped_messages\":1") == 0 ||
       strstr(json, "\"total_backpressure_events\":1") == 0 ||
+      strstr(json, "\"lookup_cache_hits\":") == 0 ||
+      strstr(json, "\"lookup_cache_misses\":") == 0 ||
       strstr(json, "\"channel_id\":42") == 0 ||
-      strstr(json, "\"inflight_bytes\":160") == 0) {
+      strstr(json, "\"inflight_bytes\":150") == 0) {
     fprintf(stderr, "ipc snapshot mismatch: %s\n", json);
     return 1;
   }
@@ -786,10 +792,16 @@ static int test_memory_zone_accounting_and_reclaim_hooks(void) {
     fprintf(stderr, "memory zone release failed\n");
     return 1;
   }
+  if (aegis_memory_zone_release(&table, 1u, 50u) != 0) {
+    fprintf(stderr, "memory zone hot-zone cache path release failed\n");
+    return 1;
+  }
   if (aegis_memory_zone_snapshot_json(&table, json, sizeof(json)) <= 0 ||
       strstr(json, "\"schema_version\":1") == 0 ||
       strstr(json, "\"denied_charges\":2") == 0 ||
       strstr(json, "\"reclaim_events\":2") == 0 ||
+      strstr(json, "\"lookup_cache_hits\":") == 0 ||
+      strstr(json, "\"lookup_cache_misses\":") == 0 ||
       strstr(json, "\"zone_id\":1") == 0 ||
       strstr(json, "\"reclaim_successes\":1") == 0) {
     fprintf(stderr, "memory zone snapshot mismatch: %s\n", json);


### PR DESCRIPTION
## Summary
- add IPC channel lookup-cache fast path for hot channel IDs
- add memory zone lookup-cache fast path for hot zone IDs
- expose cache hit/miss telemetry in IPC and memory snapshot JSON
- extend kernel tests to exercise cache path behavior and telemetry fields
- document new lookup-cache optimizations in kernel and root docs

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #161
Closes #162