### PR TITLE
feat: kernel VM/syscall lookup-cache fast paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This repository contains:
 - Namespace isolation simulator with local/global PID translation and visibility checks.
 - Atomic update rollback-index monotonic guard store with tamper-checked persistence.
 - Syscall capability gate matrix with decision-cache fast path, enforcement counters, and JSON snapshot.
+- Syscall gate rule/process lookup-cache fast paths plus VM query lookup-cache telemetry for lower hot-path overhead.
 - IPC channel quota/backpressure simulator with inflight accounting and drop metrics.
 - Memory zone accounting with reclaim hooks and low-memory deny telemetry.
 - Update release channel pinning policy with downgrade rejection guardrails.

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -7,6 +7,7 @@ Kernel direction, interfaces, and implementation notes live here.
 - `aegis_vm_space_t`: virtual memory region mapping abstraction.
   - supports map/unmap/query with overlap/overflow guards.
   - supports exact-region permission flag updates and region split helper for pager preparation.
+  - includes query lookup-cache fast path for repeated hot-address lookups.
   - exposes JSON summary endpoint for VM map observability.
 - `aegis_ipc_envelope_t`: IPC channel envelope format helper.
   - supports fixed-size encode/decode and schema/payload validation checks.
@@ -42,6 +43,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - supports disk-backed journal save and boot-time replay for crash recovery.
 - `aegis_syscall_gate_matrix_t`: syscall capability enforcement matrix.
   - includes decision-cache fast path for hot process/syscall pairs.
+  - includes process/rule lookup-cache fast paths to reduce repeated linear scans.
   - preserves deny-reason counters while reducing repeated linear scans.
 - `aegis_ipc_channel_table_t` and `aegis_memory_zone_table_t`:
   - include lookup-cache fast paths for hot channel/zone IDs.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -29,6 +29,11 @@ typedef struct {
 typedef struct {
   aegis_vm_region_t regions[AEGIS_VM_REGION_CAPACITY];
   size_t count;
+  uint64_t lookup_cache_query_address;
+  uint16_t lookup_cache_query_index;
+  uint8_t lookup_cache_valid;
+  uint64_t lookup_cache_hits;
+  uint64_t lookup_cache_misses;
 } aegis_vm_space_t;
 
 typedef struct {
@@ -198,6 +203,16 @@ typedef struct {
   uint64_t decision_cache_hits;
   uint64_t decision_cache_misses;
   uint32_t decision_cache_generation;
+  uint32_t process_lookup_cache_process_id;
+  uint16_t process_lookup_cache_index;
+  uint8_t process_lookup_cache_valid;
+  uint64_t process_lookup_cache_hits;
+  uint64_t process_lookup_cache_misses;
+  uint16_t rule_lookup_cache_syscall_id;
+  uint16_t rule_lookup_cache_index;
+  uint8_t rule_lookup_cache_valid;
+  uint64_t rule_lookup_cache_hits;
+  uint64_t rule_lookup_cache_misses;
 } aegis_syscall_gate_matrix_t;
 
 typedef struct {

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -167,6 +167,11 @@ void aegis_vm_space_init(aegis_vm_space_t *space) {
     space->regions[i].flags = 0u;
     space->regions[i].active = 0u;
   }
+  space->lookup_cache_query_address = 0u;
+  space->lookup_cache_query_index = 0u;
+  space->lookup_cache_valid = 0u;
+  space->lookup_cache_hits = 0u;
+  space->lookup_cache_misses = 0u;
 }
 
 int aegis_vm_map(aegis_vm_space_t *space, uint64_t base, uint64_t size, uint32_t flags) {
@@ -196,6 +201,7 @@ int aegis_vm_map(aegis_vm_space_t *space, uint64_t base, uint64_t size, uint32_t
     region->flags = flags;
     region->active = 1u;
     space->count += 1u;
+    space->lookup_cache_valid = 0u;
     return 0;
   }
   return -1;
@@ -219,6 +225,7 @@ int aegis_vm_unmap(aegis_vm_space_t *space, uint64_t base, uint64_t size) {
       if (space->count > 0u) {
         space->count -= 1u;
       }
+      space->lookup_cache_valid = 0u;
       return 0;
     }
   }
@@ -237,6 +244,7 @@ int aegis_vm_update_flags(aegis_vm_space_t *space, uint64_t base, uint64_t size,
     }
     if (region->base == base && region->size == size) {
       region->flags = flags;
+      space->lookup_cache_valid = 0u;
       return 0;
     }
   }
@@ -279,6 +287,7 @@ int aegis_vm_split_region(aegis_vm_space_t *space,
     space->regions[free_index].flags = space->regions[target_index].flags;
     space->regions[free_index].active = 1u;
     space->count += 1u;
+    space->lookup_cache_valid = 0u;
     return 0;
   }
 }
@@ -288,6 +297,15 @@ int aegis_vm_query(const aegis_vm_space_t *space, uint64_t address, aegis_vm_reg
   if (space == 0 || region == 0) {
     return -1;
   }
+  if (space->lookup_cache_valid != 0u &&
+      space->lookup_cache_query_index < AEGIS_VM_REGION_CAPACITY &&
+      space->regions[space->lookup_cache_query_index].active != 0u &&
+      space->lookup_cache_query_address == address) {
+    *region = space->regions[space->lookup_cache_query_index];
+    ((aegis_vm_space_t *)space)->lookup_cache_hits += 1u;
+    return 0;
+  }
+  ((aegis_vm_space_t *)space)->lookup_cache_misses += 1u;
   for (i = 0; i < AEGIS_VM_REGION_CAPACITY; ++i) {
     const aegis_vm_region_t *entry = &space->regions[i];
     if (entry->active == 0u) {
@@ -295,6 +313,9 @@ int aegis_vm_query(const aegis_vm_space_t *space, uint64_t address, aegis_vm_reg
     }
     if (address >= entry->base && address < (entry->base + entry->size)) {
       *region = *entry;
+      ((aegis_vm_space_t *)space)->lookup_cache_valid = 1u;
+      ((aegis_vm_space_t *)space)->lookup_cache_query_address = address;
+      ((aegis_vm_space_t *)space)->lookup_cache_query_index = (uint16_t)i;
       return 0;
     }
   }
@@ -311,8 +332,11 @@ int aegis_vm_summary_json(const aegis_vm_space_t *space, char *out, size_t out_s
   }
   written = snprintf(out,
                      out_size,
-                     "{\"schema_version\":1,\"region_count\":%llu,\"regions\":[",
-                     (unsigned long long)space->count);
+                     "{\"schema_version\":1,\"region_count\":%llu,"
+                     "\"lookup_cache_hits\":%llu,\"lookup_cache_misses\":%llu,\"regions\":[",
+                     (unsigned long long)space->count,
+                     (unsigned long long)space->lookup_cache_hits,
+                     (unsigned long long)space->lookup_cache_misses);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }
@@ -2009,10 +2033,23 @@ static int syscall_process_find_index(const aegis_syscall_gate_matrix_t *matrix,
   if (matrix == 0 || index_out == 0 || process_id == 0u) {
     return 0;
   }
+  if (matrix->process_lookup_cache_valid != 0u &&
+      matrix->process_lookup_cache_process_id == process_id &&
+      matrix->process_lookup_cache_index < AEGIS_SYSCALL_GATE_CAPACITY &&
+      matrix->process_caps[matrix->process_lookup_cache_index].active != 0u &&
+      matrix->process_caps[matrix->process_lookup_cache_index].process_id == process_id) {
+    *index_out = matrix->process_lookup_cache_index;
+    ((aegis_syscall_gate_matrix_t *)matrix)->process_lookup_cache_hits += 1u;
+    return 1;
+  }
+  ((aegis_syscall_gate_matrix_t *)matrix)->process_lookup_cache_misses += 1u;
   for (i = 0; i < AEGIS_SYSCALL_GATE_CAPACITY; ++i) {
     if (matrix->process_caps[i].active != 0u &&
         matrix->process_caps[i].process_id == process_id) {
       *index_out = i;
+      ((aegis_syscall_gate_matrix_t *)matrix)->process_lookup_cache_valid = 1u;
+      ((aegis_syscall_gate_matrix_t *)matrix)->process_lookup_cache_process_id = process_id;
+      ((aegis_syscall_gate_matrix_t *)matrix)->process_lookup_cache_index = (uint16_t)i;
       return 1;
     }
   }
@@ -2026,10 +2063,23 @@ static int syscall_rule_find_index(const aegis_syscall_gate_matrix_t *matrix,
   if (matrix == 0 || index_out == 0 || syscall_id == 0u) {
     return 0;
   }
+  if (matrix->rule_lookup_cache_valid != 0u &&
+      matrix->rule_lookup_cache_syscall_id == syscall_id &&
+      matrix->rule_lookup_cache_index < AEGIS_SYSCALL_RULE_CAPACITY &&
+      matrix->rules[matrix->rule_lookup_cache_index].active != 0u &&
+      matrix->rules[matrix->rule_lookup_cache_index].syscall_id == syscall_id) {
+    *index_out = matrix->rule_lookup_cache_index;
+    ((aegis_syscall_gate_matrix_t *)matrix)->rule_lookup_cache_hits += 1u;
+    return 1;
+  }
+  ((aegis_syscall_gate_matrix_t *)matrix)->rule_lookup_cache_misses += 1u;
   for (i = 0; i < AEGIS_SYSCALL_RULE_CAPACITY; ++i) {
     if (matrix->rules[i].active != 0u &&
         matrix->rules[i].syscall_id == syscall_id) {
       *index_out = i;
+      ((aegis_syscall_gate_matrix_t *)matrix)->rule_lookup_cache_valid = 1u;
+      ((aegis_syscall_gate_matrix_t *)matrix)->rule_lookup_cache_syscall_id = syscall_id;
+      ((aegis_syscall_gate_matrix_t *)matrix)->rule_lookup_cache_index = (uint16_t)i;
       return 1;
     }
   }
@@ -2106,6 +2156,16 @@ void aegis_syscall_gate_matrix_init(aegis_syscall_gate_matrix_t *matrix) {
   matrix->decision_cache_hits = 0u;
   matrix->decision_cache_misses = 0u;
   matrix->decision_cache_generation = 1u;
+  matrix->process_lookup_cache_process_id = 0u;
+  matrix->process_lookup_cache_index = 0u;
+  matrix->process_lookup_cache_valid = 0u;
+  matrix->process_lookup_cache_hits = 0u;
+  matrix->process_lookup_cache_misses = 0u;
+  matrix->rule_lookup_cache_syscall_id = 0u;
+  matrix->rule_lookup_cache_index = 0u;
+  matrix->rule_lookup_cache_valid = 0u;
+  matrix->rule_lookup_cache_hits = 0u;
+  matrix->rule_lookup_cache_misses = 0u;
 }
 
 int aegis_syscall_gate_set_process_caps(aegis_syscall_gate_matrix_t *matrix,
@@ -2118,6 +2178,9 @@ int aegis_syscall_gate_set_process_caps(aegis_syscall_gate_matrix_t *matrix,
   }
   if (syscall_process_find_index(matrix, process_id, &existing)) {
     matrix->process_caps[existing].granted_capabilities = granted_capabilities;
+    matrix->process_lookup_cache_valid = 1u;
+    matrix->process_lookup_cache_process_id = process_id;
+    matrix->process_lookup_cache_index = (uint16_t)existing;
     syscall_gate_cache_invalidate(matrix);
     return 0;
   }
@@ -2128,6 +2191,9 @@ int aegis_syscall_gate_set_process_caps(aegis_syscall_gate_matrix_t *matrix,
     matrix->process_caps[i].process_id = process_id;
     matrix->process_caps[i].granted_capabilities = granted_capabilities;
     matrix->process_caps[i].active = 1u;
+    matrix->process_lookup_cache_valid = 1u;
+    matrix->process_lookup_cache_process_id = process_id;
+    matrix->process_lookup_cache_index = (uint16_t)i;
     syscall_gate_cache_invalidate(matrix);
     return 0;
   }
@@ -2145,6 +2211,10 @@ int aegis_syscall_gate_remove_process(aegis_syscall_gate_matrix_t *matrix, uint3
   matrix->process_caps[existing].active = 0u;
   matrix->process_caps[existing].process_id = 0u;
   matrix->process_caps[existing].granted_capabilities = 0u;
+  if (matrix->process_lookup_cache_valid != 0u &&
+      matrix->process_lookup_cache_process_id == process_id) {
+    matrix->process_lookup_cache_valid = 0u;
+  }
   syscall_gate_cache_invalidate(matrix);
   return 0;
 }
@@ -2166,6 +2236,9 @@ int aegis_syscall_gate_set_rule(aegis_syscall_gate_matrix_t *matrix,
     matrix->rules[existing].syscall_class = syscall_class;
     matrix->rules[existing].required_capability = required_capability;
     matrix->rules[existing].policy_gate_required = policy_gate_required != 0u ? 1u : 0u;
+    matrix->rule_lookup_cache_valid = 1u;
+    matrix->rule_lookup_cache_syscall_id = syscall_id;
+    matrix->rule_lookup_cache_index = (uint16_t)existing;
     syscall_gate_cache_invalidate(matrix);
     return 0;
   }
@@ -2178,6 +2251,9 @@ int aegis_syscall_gate_set_rule(aegis_syscall_gate_matrix_t *matrix,
     matrix->rules[i].required_capability = required_capability;
     matrix->rules[i].policy_gate_required = policy_gate_required != 0u ? 1u : 0u;
     matrix->rules[i].active = 1u;
+    matrix->rule_lookup_cache_valid = 1u;
+    matrix->rule_lookup_cache_syscall_id = syscall_id;
+    matrix->rule_lookup_cache_index = (uint16_t)i;
     syscall_gate_cache_invalidate(matrix);
     return 0;
   }
@@ -2267,6 +2343,8 @@ int aegis_syscall_gate_snapshot_json(const aegis_syscall_gate_matrix_t *matrix,
                      "\"deny_missing_rule_count\":%llu,\"deny_missing_process_count\":%llu,"
                      "\"deny_missing_capability_count\":%llu,\"deny_policy_gate_count\":%llu,"
                      "\"decision_cache_hits\":%llu,\"decision_cache_misses\":%llu,"
+                     "\"process_lookup_cache_hits\":%llu,\"process_lookup_cache_misses\":%llu,"
+                     "\"rule_lookup_cache_hits\":%llu,\"rule_lookup_cache_misses\":%llu,"
                      "\"rules\":[",
                      (unsigned long long)matrix->allow_count,
                      (unsigned long long)matrix->deny_missing_rule_count,
@@ -2274,7 +2352,11 @@ int aegis_syscall_gate_snapshot_json(const aegis_syscall_gate_matrix_t *matrix,
                      (unsigned long long)matrix->deny_missing_capability_count,
                      (unsigned long long)matrix->deny_policy_gate_count,
                      (unsigned long long)matrix->decision_cache_hits,
-                     (unsigned long long)matrix->decision_cache_misses);
+                     (unsigned long long)matrix->decision_cache_misses,
+                     (unsigned long long)matrix->process_lookup_cache_hits,
+                     (unsigned long long)matrix->process_lookup_cache_misses,
+                     (unsigned long long)matrix->rule_lookup_cache_hits,
+                     (unsigned long long)matrix->rule_lookup_cache_misses);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -36,6 +36,10 @@ static int test_vm_region_map_abstraction(void) {
     fprintf(stderr, "vm query region lookup failed\n");
     return 1;
   }
+  if (aegis_vm_query(&space, 0x1100u, &region) != 0 || region.base != 0x1000u) {
+    fprintf(stderr, "vm query cache-hit lookup failed\n");
+    return 1;
+  }
   if (aegis_vm_query(&space, 0x9000u, &region) == 0) {
     fprintf(stderr, "vm query expected miss for unmapped address\n");
     return 1;
@@ -50,6 +54,8 @@ static int test_vm_region_map_abstraction(void) {
   }
   if (strstr(summary, "\"schema_version\":1") == 0 ||
       strstr(summary, "\"region_count\":1") == 0 ||
+      strstr(summary, "\"lookup_cache_hits\":1") == 0 ||
+      strstr(summary, "\"lookup_cache_misses\":2") == 0 ||
       strstr(summary, "\"base\":16384") == 0) {
     fprintf(stderr, "vm summary json missing expected fields: %s\n", summary);
     return 1;
@@ -86,6 +92,10 @@ static int test_vm_region_split_and_permission_update(void) {
     fprintf(stderr, "vm query after flag update failed\n");
     return 1;
   }
+  if (aegis_vm_query(&space, 0x9001u, &region) != 0 || region.flags != 0x7u) {
+    fprintf(stderr, "vm query cache-hit after flag update failed\n");
+    return 1;
+  }
   if (aegis_vm_split_region(&space, 0x8000u, 0x1000u, 0x1000u) == 0) {
     fprintf(stderr, "vm split with boundary offset should fail\n");
     return 1;
@@ -98,7 +108,10 @@ static int test_vm_region_split_and_permission_update(void) {
     fprintf(stderr, "vm split summary generation failed\n");
     return 1;
   }
-  if (strstr(summary, "\"region_count\":2") == 0 || strstr(summary, "\"flags\":7") == 0) {
+  if (strstr(summary, "\"region_count\":2") == 0 ||
+      strstr(summary, "\"lookup_cache_hits\":1") == 0 ||
+      strstr(summary, "\"lookup_cache_misses\":1") == 0 ||
+      strstr(summary, "\"flags\":7") == 0) {
     fprintf(stderr, "vm split summary missing expected fields: %s\n", summary);
     return 1;
   }
@@ -693,6 +706,10 @@ static int test_syscall_capability_gate_matrix(void) {
       strstr(json, "\"deny_policy_gate_count\":1") == 0 ||
       strstr(json, "\"decision_cache_hits\":1") == 0 ||
       strstr(json, "\"decision_cache_misses\":6") == 0 ||
+      strstr(json, "\"process_lookup_cache_hits\":") == 0 ||
+      strstr(json, "\"process_lookup_cache_misses\":") == 0 ||
+      strstr(json, "\"rule_lookup_cache_hits\":") == 0 ||
+      strstr(json, "\"rule_lookup_cache_misses\":") == 0 ||
       strstr(json, "\"syscall_id\":100") == 0 ||
       strstr(json, "\"process_id\":7001") == 0) {
     fprintf(stderr, "syscall gate snapshot mismatch: %s\n", json);


### PR DESCRIPTION
## Summary\n- add VM query lookup-cache fast path and hit/miss telemetry\n- add syscall process/rule lookup-cache fast paths with snapshot counters\n- expose new cache telemetry in VM/syscall JSON snapshots\n- extend kernel simulator tests for hot-cache behavior\n\n## Validation\n- python scripts/run_clang_suite.py\n- python -m pytest -q\n- python scripts/validate_packages.py\n\nCloses #169\nCloses #170