### PR TITLE
feat: scheduler bulk operations API with telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This repository contains:
 - Adaptive scheduler quantum autotuner for improved latency vs switch-overhead balance under load.
 - Scheduler admission/ready bitmaps + turbo candidate cache reuse for lower dispatch computation overhead.
 - Scheduler PID lookup-cache fast path for lower overhead on repeated control-plane process lookups.
+- Scheduler bulk operation API (add/remove/reprioritize) with execution telemetry for high-churn workloads.
 - IPC channel and memory zone lookup-cache fast paths to reduce hot-ID linear scan overhead.
 - Namespace translation lookup-cache and scheduler percentile-selection fast path for lower runtime metrics overhead.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -36,6 +36,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - includes aggregate wait report (`mean`, `p95`, `max`) for tuning and diagnostics.
   - wait-report percentile path now uses selection-based computation to reduce metrics overhead.
   - includes PID lookup-cache fast path for repeated scheduler control-plane queries.
+  - includes bulk scheduler operation API (`add/remove/reprioritize`) with execution telemetry counters.
   - includes wait-report snapshot endpoint with capture tick and queue metadata.
 - `aegis_process_checkpoint_table_t`: process checkpoint capture/restore for recovery workflows.
   - supports process runtime registration and per-reason checkpoint capture.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -96,6 +96,10 @@ typedef struct {
   uint8_t pid_lookup_cache_valid;
   uint64_t pid_lookup_cache_hits;
   uint64_t pid_lookup_cache_misses;
+  uint64_t bulk_apply_calls;
+  uint64_t bulk_ops_total;
+  uint64_t bulk_ops_succeeded;
+  uint64_t bulk_ops_failed;
   uint32_t turbo_last_pid;
   size_t count;
   size_t head;
@@ -158,11 +162,29 @@ typedef enum {
 } aegis_scheduler_dispatch_strategy_t;
 
 typedef enum {
+  AEGIS_SCHED_BULK_OP_ADD = 1,
+  AEGIS_SCHED_BULK_OP_REMOVE = 2,
+  AEGIS_SCHED_BULK_OP_SET_PRIORITY = 3
+} aegis_scheduler_bulk_op_code_t;
+
+typedef enum {
   AEGIS_SCHED_ADMISSION_PROFILE_CUSTOM = 0,
   AEGIS_SCHED_ADMISSION_PROFILE_MINIMAL = 1,
   AEGIS_SCHED_ADMISSION_PROFILE_DESKTOP = 2,
   AEGIS_SCHED_ADMISSION_PROFILE_SERVER = 3
 } aegis_scheduler_admission_profile_t;
+
+typedef struct {
+  uint8_t operation;
+  uint32_t process_id;
+  uint8_t priority;
+} aegis_scheduler_bulk_op_t;
+
+typedef struct {
+  uint8_t operation;
+  uint32_t process_id;
+  int32_t status;
+} aegis_scheduler_bulk_result_t;
 
 typedef enum {
   AEGIS_SYSCALL_CLASS_FS = 1,
@@ -397,6 +419,12 @@ int aegis_scheduler_add_with_priority(aegis_scheduler_t *scheduler, uint32_t pro
                                       uint8_t priority);
 int aegis_scheduler_remove(aegis_scheduler_t *scheduler, uint32_t process_id);
 int aegis_scheduler_set_priority(aegis_scheduler_t *scheduler, uint32_t process_id, uint8_t priority);
+int aegis_scheduler_apply_batch(aegis_scheduler_t *scheduler,
+                                const aegis_scheduler_bulk_op_t *ops,
+                                size_t op_count,
+                                aegis_scheduler_bulk_result_t *results,
+                                size_t results_capacity,
+                                size_t *applied_count_out);
 int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id);
 size_t aegis_scheduler_count(const aegis_scheduler_t *scheduler);
 uint64_t aegis_scheduler_total_dispatches(const aegis_scheduler_t *scheduler);

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -627,6 +627,10 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->pid_lookup_cache_valid = 0u;
   scheduler->pid_lookup_cache_hits = 0u;
   scheduler->pid_lookup_cache_misses = 0u;
+  scheduler->bulk_apply_calls = 0u;
+  scheduler->bulk_ops_total = 0u;
+  scheduler->bulk_ops_succeeded = 0u;
+  scheduler->bulk_ops_failed = 0u;
   scheduler->turbo_last_pid = 0u;
   scheduler->admission_profile_id = AEGIS_SCHED_ADMISSION_PROFILE_CUSTOM;
   scheduler->runnable_credit_count = 0u;
@@ -666,6 +670,10 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->pid_lookup_cache_valid = 0u;
   scheduler->pid_lookup_cache_hits = 0u;
   scheduler->pid_lookup_cache_misses = 0u;
+  scheduler->bulk_apply_calls = 0u;
+  scheduler->bulk_ops_total = 0u;
+  scheduler->bulk_ops_succeeded = 0u;
+  scheduler->bulk_ops_failed = 0u;
   scheduler->quantum_autotune_last_tick = 0u;
   scheduler->quantum_autotune_last_switch_total = 0u;
   scheduler->quantum_autotune_adjustments = 0u;
@@ -846,6 +854,49 @@ int aegis_scheduler_set_priority(aegis_scheduler_t *scheduler, uint32_t process_
   return 0;
 }
 
+int aegis_scheduler_apply_batch(aegis_scheduler_t *scheduler,
+                                const aegis_scheduler_bulk_op_t *ops,
+                                size_t op_count,
+                                aegis_scheduler_bulk_result_t *results,
+                                size_t results_capacity,
+                                size_t *applied_count_out) {
+  size_t i;
+  size_t applied = 0u;
+  if (scheduler == 0 || ops == 0u || op_count == 0u) {
+    return -1;
+  }
+  scheduler->bulk_apply_calls += 1u;
+  for (i = 0u; i < op_count; ++i) {
+    int status = -1;
+    const aegis_scheduler_bulk_op_t *op = &ops[i];
+    if (op->operation == AEGIS_SCHED_BULK_OP_ADD) {
+      status = aegis_scheduler_add_with_priority(scheduler, op->process_id, op->priority);
+    } else if (op->operation == AEGIS_SCHED_BULK_OP_REMOVE) {
+      status = aegis_scheduler_remove(scheduler, op->process_id);
+    } else if (op->operation == AEGIS_SCHED_BULK_OP_SET_PRIORITY) {
+      status = aegis_scheduler_set_priority(scheduler, op->process_id, op->priority);
+    } else {
+      status = -1;
+    }
+    scheduler->bulk_ops_total += 1u;
+    if (status == 0) {
+      scheduler->bulk_ops_succeeded += 1u;
+      applied += 1u;
+    } else {
+      scheduler->bulk_ops_failed += 1u;
+    }
+    if (results != 0u && i < results_capacity) {
+      results[i].operation = op->operation;
+      results[i].process_id = op->process_id;
+      results[i].status = status;
+    }
+  }
+  if (applied_count_out != 0u) {
+    *applied_count_out = applied;
+  }
+  return 0;
+}
+
 int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
   size_t attempts;
   size_t chosen_idx = 0u;
@@ -969,6 +1020,10 @@ void aegis_scheduler_reset_metrics(aegis_scheduler_t *scheduler) {
   scheduler->pid_lookup_cache_valid = 0u;
   scheduler->pid_lookup_cache_hits = 0u;
   scheduler->pid_lookup_cache_misses = 0u;
+  scheduler->bulk_apply_calls = 0u;
+  scheduler->bulk_ops_total = 0u;
+  scheduler->bulk_ops_succeeded = 0u;
+  scheduler->bulk_ops_failed = 0u;
   scheduler->quantum_autotune_last_tick = scheduler->scheduler_ticks;
   scheduler->quantum_autotune_last_switch_total = 0u;
   scheduler->quantum_autotune_adjustments = 0u;
@@ -1632,6 +1687,8 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      "{\"schema_version\":1,\"profile_id\":%u,\"queue_depth\":%llu,"
                      "\"priority_present_bitmap\":%u,\"runnable_priority_bitmap\":%u,"
                      "\"pid_lookup_cache_hits\":%llu,\"pid_lookup_cache_misses\":%llu,"
+                     "\"bulk_apply_calls\":%llu,\"bulk_ops_total\":%llu,"
+                     "\"bulk_ops_succeeded\":%llu,\"bulk_ops_failed\":%llu,"
                      "\"limits\":{\"high\":%u,\"normal\":%u,\"low\":%u},"
                      "\"counts\":{\"high\":%u,\"normal\":%u,\"low\":%u},"
                      "\"drops\":{\"high\":%llu,\"normal\":%llu,\"low\":%llu}}",
@@ -1641,6 +1698,10 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      (unsigned int)scheduler->runnable_priority_bitmap,
                      (unsigned long long)scheduler->pid_lookup_cache_hits,
                      (unsigned long long)scheduler->pid_lookup_cache_misses,
+                     (unsigned long long)scheduler->bulk_apply_calls,
+                     (unsigned long long)scheduler->bulk_ops_total,
+                     (unsigned long long)scheduler->bulk_ops_succeeded,
+                     (unsigned long long)scheduler->bulk_ops_failed,
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_HIGH],
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_NORMAL],
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_LOW],

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -464,6 +464,10 @@ static int test_scheduler_admission_limits_and_snapshot(void) {
   if (strstr(json, "\"schema_version\":1") == 0 ||
       strstr(json, "\"pid_lookup_cache_hits\":") == 0 ||
       strstr(json, "\"pid_lookup_cache_misses\":") == 0 ||
+      strstr(json, "\"bulk_apply_calls\":") == 0 ||
+      strstr(json, "\"bulk_ops_total\":") == 0 ||
+      strstr(json, "\"bulk_ops_succeeded\":") == 0 ||
+      strstr(json, "\"bulk_ops_failed\":") == 0 ||
       strstr(json, "\"limits\":{\"high\":1,\"normal\":2,\"low\":1}") == 0 ||
       strstr(json, "\"counts\":{\"high\":1,\"normal\":2,\"low\":0}") == 0 ||
       strstr(json, "\"drops\":{\"high\":1,\"normal\":1,\"low\":0}") == 0) {
@@ -525,6 +529,61 @@ static int test_scheduler_admission_profile_name_resolver(void) {
   }
   if (aegis_scheduler_apply_admission_profile_name(&scheduler, "unknown") == 0) {
     fprintf(stderr, "unknown profile name should fail\n");
+    return 1;
+  }
+  return 0;
+}
+
+static int test_scheduler_bulk_apply_api_and_metrics(void) {
+  aegis_scheduler_t scheduler;
+  aegis_scheduler_bulk_op_t ops[6];
+  aegis_scheduler_bulk_result_t results[6];
+  char json[512];
+  size_t applied = 0u;
+  memset(ops, 0, sizeof(ops));
+  memset(results, 0, sizeof(results));
+  aegis_scheduler_init(&scheduler);
+  ops[0].operation = AEGIS_SCHED_BULK_OP_ADD;
+  ops[0].process_id = 3001u;
+  ops[0].priority = AEGIS_PRIORITY_NORMAL;
+  ops[1].operation = AEGIS_SCHED_BULK_OP_ADD;
+  ops[1].process_id = 3002u;
+  ops[1].priority = AEGIS_PRIORITY_HIGH;
+  ops[2].operation = AEGIS_SCHED_BULK_OP_SET_PRIORITY;
+  ops[2].process_id = 3001u;
+  ops[2].priority = AEGIS_PRIORITY_LOW;
+  ops[3].operation = AEGIS_SCHED_BULK_OP_REMOVE;
+  ops[3].process_id = 3002u;
+  ops[4].operation = 99u;
+  ops[4].process_id = 9999u;
+  ops[5].operation = AEGIS_SCHED_BULK_OP_REMOVE;
+  ops[5].process_id = 7777u;
+  if (aegis_scheduler_apply_batch(&scheduler, ops, 6u, results, 6u, &applied) != 0) {
+    fprintf(stderr, "scheduler bulk apply call failed\n");
+    return 1;
+  }
+  if (applied != 4u || scheduler.count != 1u || scheduler.process_ids[0] != 3001u) {
+    fprintf(stderr, "scheduler bulk apply state mismatch\n");
+    return 1;
+  }
+  if (scheduler.bulk_apply_calls != 1u ||
+      scheduler.bulk_ops_total != 6u ||
+      scheduler.bulk_ops_succeeded != 4u ||
+      scheduler.bulk_ops_failed != 2u) {
+    fprintf(stderr, "scheduler bulk apply counters mismatch\n");
+    return 1;
+  }
+  if (results[0].status != 0 || results[1].status != 0 || results[2].status != 0 ||
+      results[3].status != 0 || results[4].status == 0 || results[5].status == 0) {
+    fprintf(stderr, "scheduler bulk apply per-op result mismatch\n");
+    return 1;
+  }
+  if (aegis_scheduler_admission_snapshot_json(&scheduler, json, sizeof(json)) <= 0 ||
+      strstr(json, "\"bulk_apply_calls\":1") == 0 ||
+      strstr(json, "\"bulk_ops_total\":6") == 0 ||
+      strstr(json, "\"bulk_ops_succeeded\":4") == 0 ||
+      strstr(json, "\"bulk_ops_failed\":2") == 0) {
+    fprintf(stderr, "scheduler bulk metrics snapshot mismatch: %s\n", json);
     return 1;
   }
   return 0;
@@ -1623,6 +1682,9 @@ int main(void) {
     return 1;
   }
   if (test_scheduler_admission_profile_name_resolver() != 0) {
+    return 1;
+  }
+  if (test_scheduler_bulk_apply_api_and_metrics() != 0) {
     return 1;
   }
   if (test_scheduler_priority_count_tracking_after_reprioritize() != 0) {


### PR DESCRIPTION
## Summary\n- add scheduler bulk operation API (dd/remove/reprioritize)\n- add per-batch and per-operation telemetry counters\n- expose bulk telemetry in scheduler admission snapshot JSON\n- add simulator tests for success/failure paths and metrics\n\n## Validation\n- python scripts/run_clang_suite.py\n- python -m pytest -q\n- python scripts/validate_packages.py\n\nCloses #173