### PR TITLE
feat: 15-issue kernel speed and cache hardening batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ This repository contains:
 - Scheduler admission/ready bitmaps + turbo candidate cache reuse for lower dispatch computation overhead.
 - Scheduler PID lookup-cache fast path for lower overhead on repeated control-plane process lookups.
 - Scheduler bulk operation API (add/remove/reprioritize) with execution telemetry for high-churn workloads.
+- Adaptive turbo scheduler reuse-budget tuning and stronger anti-runaway dispatch scoring under load.
+- Wait-latency safety clamps and enriched fairness/admission snapshot telemetry for tuning pipelines.
 - IPC channel and memory zone lookup-cache fast paths to reduce hot-ID linear scan overhead.
+- Syscall rule removal API with policy-churn telemetry (`removed_rule_count`) in syscall snapshots.
 - Namespace translation lookup-cache and scheduler percentile-selection fast path for lower runtime metrics overhead.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -37,6 +37,9 @@ Kernel direction, interfaces, and implementation notes live here.
   - wait-report percentile path now uses selection-based computation to reduce metrics overhead.
   - includes PID lookup-cache fast path for repeated scheduler control-plane queries.
   - includes bulk scheduler operation API (`add/remove/reprioritize`) with execution telemetry counters.
+  - turbo scheduler now adapts candidate cache reuse budget by queue pressure and switch patterns.
+  - turbo scoring now penalizes runaway dispatch dominance to preserve fairness under heavy load.
+  - wait-latency accounting includes safety clamps for non-monotonic tick edge cases.
   - includes wait-report snapshot endpoint with capture tick and queue metadata.
 - `aegis_process_checkpoint_table_t`: process checkpoint capture/restore for recovery workflows.
   - supports process runtime registration and per-reason checkpoint capture.
@@ -46,6 +49,7 @@ Kernel direction, interfaces, and implementation notes live here.
 - `aegis_syscall_gate_matrix_t`: syscall capability enforcement matrix.
   - includes decision-cache fast path for hot process/syscall pairs.
   - includes process/rule lookup-cache fast paths to reduce repeated linear scans.
+  - supports rule removal API with snapshot telemetry (`removed_rule_count`) for policy churn tracking.
   - preserves deny-reason counters while reducing repeated linear scans.
 - `aegis_ipc_channel_table_t` and `aegis_memory_zone_table_t`:
   - include lookup-cache fast paths for hot channel/zone IDs.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -100,6 +100,10 @@ typedef struct {
   uint64_t bulk_ops_total;
   uint64_t bulk_ops_succeeded;
   uint64_t bulk_ops_failed;
+  uint64_t bulk_ops_unknown;
+  uint64_t bulk_results_dropped;
+  uint64_t turbo_reuse_budget_adaptations;
+  uint64_t wait_latency_clamp_events;
   uint32_t turbo_last_pid;
   size_t count;
   size_t head;
@@ -240,6 +244,7 @@ typedef struct {
   uint8_t rule_lookup_cache_valid;
   uint64_t rule_lookup_cache_hits;
   uint64_t rule_lookup_cache_misses;
+  uint64_t removed_rule_count;
 } aegis_syscall_gate_matrix_t;
 
 typedef struct {
@@ -536,6 +541,7 @@ int aegis_syscall_gate_set_rule(aegis_syscall_gate_matrix_t *matrix,
                                 uint8_t syscall_class,
                                 uint32_t required_capability,
                                 uint8_t policy_gate_required);
+int aegis_syscall_gate_remove_rule(aegis_syscall_gate_matrix_t *matrix, uint16_t syscall_id);
 int aegis_syscall_gate_check(aegis_syscall_gate_matrix_t *matrix,
                              uint32_t process_id,
                              uint16_t syscall_id,

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -530,16 +530,25 @@ static int scheduler_pick_turbo_index(const aegis_scheduler_t *scheduler, size_t
   }
   ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_misses += 1u;
   for (i = 0; i < scheduler->count; ++i) {
-    uint64_t waited_ticks = scheduler->scheduler_ticks - scheduler->enqueued_tick[i];
+    uint64_t waited_ticks;
     int score;
     if (scheduler->credits[i] == 0u) {
       continue;
     }
+    if (scheduler->scheduler_ticks >= scheduler->enqueued_tick[i]) {
+      waited_ticks = scheduler->scheduler_ticks - scheduler->enqueued_tick[i];
+    } else {
+      waited_ticks = 0u;
+      ((aegis_scheduler_t *)scheduler)->wait_latency_clamp_events += 1u;
+    }
     score = (int)(scheduler->priorities[i] * scheduler->turbo_priority_weight);
     score += (int)(waited_ticks * scheduler->turbo_wait_weight);
-    score -= (int)(scheduler->dispatch_counts[i] / 4u);
+    score -= (int)(scheduler->dispatch_counts[i] / 2u);
+    if (scheduler->total_dispatches > (uint64_t)(scheduler->count * 8u)) {
+      score -= (int)(scheduler->dispatch_counts[i] / 2u);
+    }
     if (scheduler->process_ids[i] == scheduler->turbo_last_pid) {
-      score += 3;
+      score -= 2;
     }
     if (!found || score > best_score ||
         (score == best_score &&
@@ -551,6 +560,26 @@ static int scheduler_pick_turbo_index(const aegis_scheduler_t *scheduler, size_t
   }
   if (!found) {
     return 0;
+  }
+  {
+    uint8_t desired_budget = 1u;
+    if (scheduler->count >= 8u) {
+      desired_budget = 2u;
+    }
+    if (scheduler->count >= 24u) {
+      desired_budget = 3u;
+    }
+    if (scheduler->reason_switch_counts[AEGIS_SWITCH_QUANTUM_EXPIRED] >
+        scheduler->reason_switch_counts[AEGIS_SWITCH_PROCESS_START]) {
+      desired_budget = (uint8_t)(desired_budget + 1u);
+    }
+    if (desired_budget > 4u) {
+      desired_budget = 4u;
+    }
+    if (((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_max_reuse != desired_budget) {
+      ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_max_reuse = desired_budget;
+      ((aegis_scheduler_t *)scheduler)->turbo_reuse_budget_adaptations += 1u;
+    }
   }
   ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_valid = 1u;
   ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_index = (uint32_t)best_index;
@@ -631,6 +660,10 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->bulk_ops_total = 0u;
   scheduler->bulk_ops_succeeded = 0u;
   scheduler->bulk_ops_failed = 0u;
+  scheduler->bulk_ops_unknown = 0u;
+  scheduler->bulk_results_dropped = 0u;
+  scheduler->turbo_reuse_budget_adaptations = 0u;
+  scheduler->wait_latency_clamp_events = 0u;
   scheduler->turbo_last_pid = 0u;
   scheduler->admission_profile_id = AEGIS_SCHED_ADMISSION_PROFILE_CUSTOM;
   scheduler->runnable_credit_count = 0u;
@@ -674,6 +707,10 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->bulk_ops_total = 0u;
   scheduler->bulk_ops_succeeded = 0u;
   scheduler->bulk_ops_failed = 0u;
+  scheduler->bulk_ops_unknown = 0u;
+  scheduler->bulk_results_dropped = 0u;
+  scheduler->turbo_reuse_budget_adaptations = 0u;
+  scheduler->wait_latency_clamp_events = 0u;
   scheduler->quantum_autotune_last_tick = 0u;
   scheduler->quantum_autotune_last_switch_total = 0u;
   scheduler->quantum_autotune_adjustments = 0u;
@@ -862,7 +899,10 @@ int aegis_scheduler_apply_batch(aegis_scheduler_t *scheduler,
                                 size_t *applied_count_out) {
   size_t i;
   size_t applied = 0u;
-  if (scheduler == 0 || ops == 0u || op_count == 0u) {
+  if (applied_count_out != 0u) {
+    *applied_count_out = 0u;
+  }
+  if (scheduler == 0 || ops == 0u || op_count == 0u || (results == 0u && results_capacity > 0u)) {
     return -1;
   }
   scheduler->bulk_apply_calls += 1u;
@@ -877,6 +917,7 @@ int aegis_scheduler_apply_batch(aegis_scheduler_t *scheduler,
       status = aegis_scheduler_set_priority(scheduler, op->process_id, op->priority);
     } else {
       status = -1;
+      scheduler->bulk_ops_unknown += 1u;
     }
     scheduler->bulk_ops_total += 1u;
     if (status == 0) {
@@ -889,6 +930,8 @@ int aegis_scheduler_apply_batch(aegis_scheduler_t *scheduler,
       results[i].operation = op->operation;
       results[i].process_id = op->process_id;
       results[i].status = status;
+    } else if (results != 0u && i >= results_capacity) {
+      scheduler->bulk_results_dropped += 1u;
     }
   }
   if (applied_count_out != 0u) {
@@ -908,12 +951,18 @@ int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
   }
   if (scheduler->dispatch_strategy == AEGIS_SCHED_STRATEGY_TURBO &&
       scheduler_pick_turbo_index(scheduler, &chosen_idx)) {
+    uint64_t wait_delta = 0u;
     scheduler->credits[chosen_idx] -= 1;
     if (scheduler->credits[chosen_idx] == 0u) {
       scheduler_runnable_credit_dec(scheduler, scheduler->priorities[chosen_idx]);
     }
-    scheduler->last_wait_latency[chosen_idx] =
-        scheduler->scheduler_ticks - scheduler->enqueued_tick[chosen_idx];
+    if (scheduler->scheduler_ticks >= scheduler->enqueued_tick[chosen_idx]) {
+      wait_delta = scheduler->scheduler_ticks - scheduler->enqueued_tick[chosen_idx];
+    } else {
+      wait_delta = 0u;
+      scheduler->wait_latency_clamp_events += 1u;
+    }
+    scheduler->last_wait_latency[chosen_idx] = wait_delta;
     scheduler->wait_ticks_total[chosen_idx] += scheduler->last_wait_latency[chosen_idx];
     scheduler->dispatch_counts[chosen_idx] += 1;
     scheduler->total_dispatches += 1;
@@ -925,6 +974,7 @@ int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
   }
   for (attempts = 0; attempts < scheduler->count; ++attempts) {
     size_t idx = (scheduler->head + attempts) % scheduler->count;
+    uint64_t wait_delta = 0u;
     if (scheduler->credits[idx] == 0) {
       continue;
     }
@@ -932,7 +982,13 @@ int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
     if (scheduler->credits[idx] == 0u) {
       scheduler_runnable_credit_dec(scheduler, scheduler->priorities[idx]);
     }
-    scheduler->last_wait_latency[idx] = scheduler->scheduler_ticks - scheduler->enqueued_tick[idx];
+    if (scheduler->scheduler_ticks >= scheduler->enqueued_tick[idx]) {
+      wait_delta = scheduler->scheduler_ticks - scheduler->enqueued_tick[idx];
+    } else {
+      wait_delta = 0u;
+      scheduler->wait_latency_clamp_events += 1u;
+    }
+    scheduler->last_wait_latency[idx] = wait_delta;
     scheduler->wait_ticks_total[idx] += scheduler->last_wait_latency[idx];
     scheduler->dispatch_counts[idx] += 1;
     scheduler->total_dispatches += 1;
@@ -1024,6 +1080,10 @@ void aegis_scheduler_reset_metrics(aegis_scheduler_t *scheduler) {
   scheduler->bulk_ops_total = 0u;
   scheduler->bulk_ops_succeeded = 0u;
   scheduler->bulk_ops_failed = 0u;
+  scheduler->bulk_ops_unknown = 0u;
+  scheduler->bulk_results_dropped = 0u;
+  scheduler->turbo_reuse_budget_adaptations = 0u;
+  scheduler->wait_latency_clamp_events = 0u;
   scheduler->quantum_autotune_last_tick = scheduler->scheduler_ticks;
   scheduler->quantum_autotune_last_switch_total = 0u;
   scheduler->quantum_autotune_adjustments = 0u;
@@ -1585,9 +1645,18 @@ int aegis_scheduler_fairness_snapshot_json(const aegis_scheduler_t *scheduler,
   }
   written = snprintf(out,
                      out_size,
-                     "{\"schema_version\":1,\"queue_depth\":%llu,\"total_dispatches\":%llu,\"processes\":[",
+                     "{\"schema_version\":1,\"queue_depth\":%llu,\"total_dispatches\":%llu,"
+                     "\"pid_lookup_cache_hits\":%llu,\"pid_lookup_cache_misses\":%llu,"
+                     "\"bulk_apply_calls\":%llu,\"bulk_ops_total\":%llu,"
+                     "\"bulk_ops_succeeded\":%llu,\"bulk_ops_failed\":%llu,\"processes\":[",
                      (unsigned long long)scheduler->count,
-                     (unsigned long long)scheduler->total_dispatches);
+                     (unsigned long long)scheduler->total_dispatches,
+                     (unsigned long long)scheduler->pid_lookup_cache_hits,
+                     (unsigned long long)scheduler->pid_lookup_cache_misses,
+                     (unsigned long long)scheduler->bulk_apply_calls,
+                     (unsigned long long)scheduler->bulk_ops_total,
+                     (unsigned long long)scheduler->bulk_ops_succeeded,
+                     (unsigned long long)scheduler->bulk_ops_failed);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }
@@ -1689,6 +1758,9 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      "\"pid_lookup_cache_hits\":%llu,\"pid_lookup_cache_misses\":%llu,"
                      "\"bulk_apply_calls\":%llu,\"bulk_ops_total\":%llu,"
                      "\"bulk_ops_succeeded\":%llu,\"bulk_ops_failed\":%llu,"
+                     "\"bulk_ops_unknown\":%llu,\"bulk_results_dropped\":%llu,"
+                     "\"turbo_reuse_budget_adaptations\":%llu,"
+                     "\"wait_latency_clamp_events\":%llu,"
                      "\"limits\":{\"high\":%u,\"normal\":%u,\"low\":%u},"
                      "\"counts\":{\"high\":%u,\"normal\":%u,\"low\":%u},"
                      "\"drops\":{\"high\":%llu,\"normal\":%llu,\"low\":%llu}}",
@@ -1702,6 +1774,10 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      (unsigned long long)scheduler->bulk_ops_total,
                      (unsigned long long)scheduler->bulk_ops_succeeded,
                      (unsigned long long)scheduler->bulk_ops_failed,
+                     (unsigned long long)scheduler->bulk_ops_unknown,
+                     (unsigned long long)scheduler->bulk_results_dropped,
+                     (unsigned long long)scheduler->turbo_reuse_budget_adaptations,
+                     (unsigned long long)scheduler->wait_latency_clamp_events,
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_HIGH],
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_NORMAL],
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_LOW],
@@ -2282,6 +2358,7 @@ void aegis_syscall_gate_matrix_init(aegis_syscall_gate_matrix_t *matrix) {
   matrix->rule_lookup_cache_valid = 0u;
   matrix->rule_lookup_cache_hits = 0u;
   matrix->rule_lookup_cache_misses = 0u;
+  matrix->removed_rule_count = 0u;
 }
 
 int aegis_syscall_gate_set_process_caps(aegis_syscall_gate_matrix_t *matrix,
@@ -2376,6 +2453,28 @@ int aegis_syscall_gate_set_rule(aegis_syscall_gate_matrix_t *matrix,
   return -1;
 }
 
+int aegis_syscall_gate_remove_rule(aegis_syscall_gate_matrix_t *matrix, uint16_t syscall_id) {
+  size_t existing = 0u;
+  if (matrix == 0 || syscall_id == 0u) {
+    return -1;
+  }
+  if (!syscall_rule_find_index(matrix, syscall_id, &existing)) {
+    return -1;
+  }
+  matrix->rules[existing].active = 0u;
+  matrix->rules[existing].syscall_id = 0u;
+  matrix->rules[existing].syscall_class = 0u;
+  matrix->rules[existing].required_capability = 0u;
+  matrix->rules[existing].policy_gate_required = 0u;
+  if (matrix->rule_lookup_cache_valid != 0u &&
+      matrix->rule_lookup_cache_syscall_id == syscall_id) {
+    matrix->rule_lookup_cache_valid = 0u;
+  }
+  matrix->removed_rule_count += 1u;
+  syscall_gate_cache_invalidate(matrix);
+  return 0;
+}
+
 int aegis_syscall_gate_check(aegis_syscall_gate_matrix_t *matrix,
                              uint32_t process_id,
                              uint16_t syscall_id,
@@ -2461,6 +2560,7 @@ int aegis_syscall_gate_snapshot_json(const aegis_syscall_gate_matrix_t *matrix,
                      "\"decision_cache_hits\":%llu,\"decision_cache_misses\":%llu,"
                      "\"process_lookup_cache_hits\":%llu,\"process_lookup_cache_misses\":%llu,"
                      "\"rule_lookup_cache_hits\":%llu,\"rule_lookup_cache_misses\":%llu,"
+                     "\"removed_rule_count\":%llu,"
                      "\"rules\":[",
                      (unsigned long long)matrix->allow_count,
                      (unsigned long long)matrix->deny_missing_rule_count,
@@ -2472,7 +2572,8 @@ int aegis_syscall_gate_snapshot_json(const aegis_syscall_gate_matrix_t *matrix,
                      (unsigned long long)matrix->process_lookup_cache_hits,
                      (unsigned long long)matrix->process_lookup_cache_misses,
                      (unsigned long long)matrix->rule_lookup_cache_hits,
-                     (unsigned long long)matrix->rule_lookup_cache_misses);
+                     (unsigned long long)matrix->rule_lookup_cache_misses,
+                     (unsigned long long)matrix->removed_rule_count);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -468,6 +468,10 @@ static int test_scheduler_admission_limits_and_snapshot(void) {
       strstr(json, "\"bulk_ops_total\":") == 0 ||
       strstr(json, "\"bulk_ops_succeeded\":") == 0 ||
       strstr(json, "\"bulk_ops_failed\":") == 0 ||
+      strstr(json, "\"bulk_ops_unknown\":") == 0 ||
+      strstr(json, "\"bulk_results_dropped\":") == 0 ||
+      strstr(json, "\"turbo_reuse_budget_adaptations\":") == 0 ||
+      strstr(json, "\"wait_latency_clamp_events\":") == 0 ||
       strstr(json, "\"limits\":{\"high\":1,\"normal\":2,\"low\":1}") == 0 ||
       strstr(json, "\"counts\":{\"high\":1,\"normal\":2,\"low\":0}") == 0 ||
       strstr(json, "\"drops\":{\"high\":1,\"normal\":1,\"low\":0}") == 0) {
@@ -537,7 +541,7 @@ static int test_scheduler_admission_profile_name_resolver(void) {
 static int test_scheduler_bulk_apply_api_and_metrics(void) {
   aegis_scheduler_t scheduler;
   aegis_scheduler_bulk_op_t ops[6];
-  aegis_scheduler_bulk_result_t results[6];
+  aegis_scheduler_bulk_result_t results[3];
   char json[512];
   size_t applied = 0u;
   memset(ops, 0, sizeof(ops));
@@ -558,7 +562,7 @@ static int test_scheduler_bulk_apply_api_and_metrics(void) {
   ops[4].process_id = 9999u;
   ops[5].operation = AEGIS_SCHED_BULK_OP_REMOVE;
   ops[5].process_id = 7777u;
-  if (aegis_scheduler_apply_batch(&scheduler, ops, 6u, results, 6u, &applied) != 0) {
+  if (aegis_scheduler_apply_batch(&scheduler, ops, 6u, results, 3u, &applied) != 0) {
     fprintf(stderr, "scheduler bulk apply call failed\n");
     return 1;
   }
@@ -569,12 +573,13 @@ static int test_scheduler_bulk_apply_api_and_metrics(void) {
   if (scheduler.bulk_apply_calls != 1u ||
       scheduler.bulk_ops_total != 6u ||
       scheduler.bulk_ops_succeeded != 4u ||
-      scheduler.bulk_ops_failed != 2u) {
+      scheduler.bulk_ops_failed != 2u ||
+      scheduler.bulk_ops_unknown != 1u ||
+      scheduler.bulk_results_dropped != 3u) {
     fprintf(stderr, "scheduler bulk apply counters mismatch\n");
     return 1;
   }
-  if (results[0].status != 0 || results[1].status != 0 || results[2].status != 0 ||
-      results[3].status != 0 || results[4].status == 0 || results[5].status == 0) {
+  if (results[0].status != 0 || results[1].status != 0 || results[2].status != 0) {
     fprintf(stderr, "scheduler bulk apply per-op result mismatch\n");
     return 1;
   }
@@ -582,8 +587,74 @@ static int test_scheduler_bulk_apply_api_and_metrics(void) {
       strstr(json, "\"bulk_apply_calls\":1") == 0 ||
       strstr(json, "\"bulk_ops_total\":6") == 0 ||
       strstr(json, "\"bulk_ops_succeeded\":4") == 0 ||
-      strstr(json, "\"bulk_ops_failed\":2") == 0) {
+      strstr(json, "\"bulk_ops_failed\":2") == 0 ||
+      strstr(json, "\"bulk_ops_unknown\":1") == 0 ||
+      strstr(json, "\"bulk_results_dropped\":3") == 0) {
     fprintf(stderr, "scheduler bulk metrics snapshot mismatch: %s\n", json);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_vm_query_cache_invalidation_after_mutation(void) {
+  aegis_vm_space_t space;
+  aegis_vm_region_t region;
+  char summary[1024];
+  aegis_vm_space_init(&space);
+  if (aegis_vm_map(&space, 0x10000u, 0x2000u, 0x3u) != 0) {
+    fprintf(stderr, "vm invalidation setup map failed\n");
+    return 1;
+  }
+  if (aegis_vm_query(&space, 0x10010u, &region) != 0) {
+    fprintf(stderr, "vm invalidation setup query failed\n");
+    return 1;
+  }
+  if (aegis_vm_unmap(&space, 0x10000u, 0x2000u) != 0) {
+    fprintf(stderr, "vm invalidation unmap failed\n");
+    return 1;
+  }
+  if (aegis_vm_query(&space, 0x10010u, &region) == 0) {
+    fprintf(stderr, "vm invalidation expected miss after unmap\n");
+    return 1;
+  }
+  if (aegis_vm_map(&space, 0x10000u, 0x2000u, 0x1u) != 0 ||
+      aegis_vm_query(&space, 0x10010u, &region) != 0 ||
+      region.flags != 0x1u) {
+    fprintf(stderr, "vm invalidation remap/requery mismatch\n");
+    return 1;
+  }
+  if (aegis_vm_summary_json(&space, summary, sizeof(summary)) <= 0 ||
+      strstr(summary, "\"lookup_cache_hits\":") == 0 ||
+      strstr(summary, "\"lookup_cache_misses\":") == 0) {
+    fprintf(stderr, "vm invalidation summary missing cache telemetry: %s\n", summary);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_scheduler_bulk_apply_rejection_paths(void) {
+  aegis_scheduler_t scheduler;
+  aegis_scheduler_bulk_op_t op;
+  size_t applied = 99u;
+  memset(&op, 0, sizeof(op));
+  op.operation = AEGIS_SCHED_BULK_OP_ADD;
+  op.process_id = 4001u;
+  op.priority = AEGIS_PRIORITY_NORMAL;
+  aegis_scheduler_init(&scheduler);
+  if (aegis_scheduler_apply_batch(&scheduler, &op, 0u, 0, 0u, &applied) == 0) {
+    fprintf(stderr, "scheduler bulk empty-batch should fail\n");
+    return 1;
+  }
+  if (applied != 0u) {
+    fprintf(stderr, "scheduler bulk empty-batch should zero applied count\n");
+    return 1;
+  }
+  if (aegis_scheduler_apply_batch(&scheduler, &op, 1u, 0, 1u, &applied) == 0) {
+    fprintf(stderr, "scheduler bulk results-capacity without buffer should fail\n");
+    return 1;
+  }
+  if (aegis_scheduler_apply_batch(0, &op, 1u, 0, 0u, &applied) == 0) {
+    fprintf(stderr, "scheduler bulk null scheduler should fail\n");
     return 1;
   }
   return 0;
@@ -768,19 +839,37 @@ static int test_syscall_capability_gate_matrix(void) {
     fprintf(stderr, "expected cached syscall 200 deny missing capability\n");
     return 1;
   }
+  if (aegis_syscall_gate_set_rule(&matrix, 200u, AEGIS_SYSCALL_CLASS_NET, 0x1u, 0u) != 0) {
+    fprintf(stderr, "expected syscall rule update for 200\n");
+    return 1;
+  }
+  if (aegis_syscall_gate_check(&matrix, 7002u, 200u, 1u, &allowed) != 1 || allowed != 1u) {
+    fprintf(stderr, "expected syscall 200 allow after rule update\n");
+    return 1;
+  }
+  if (aegis_syscall_gate_remove_rule(&matrix, 300u) != 0 ||
+      aegis_syscall_gate_remove_rule(&matrix, 300u) == 0) {
+    fprintf(stderr, "expected syscall rule removal behavior for 300\n");
+    return 1;
+  }
+  if (aegis_syscall_gate_check(&matrix, 7001u, 300u, 1u, &allowed) != 0 || allowed != 0u) {
+    fprintf(stderr, "expected removed syscall 300 to deny by missing rule\n");
+    return 1;
+  }
   if (aegis_syscall_gate_snapshot_json(&matrix, json, sizeof(json)) <= 0 ||
       strstr(json, "\"schema_version\":1") == 0 ||
-      strstr(json, "\"allow_count\":2") == 0 ||
-      strstr(json, "\"deny_missing_rule_count\":1") == 0 ||
+      strstr(json, "\"allow_count\":3") == 0 ||
+      strstr(json, "\"deny_missing_rule_count\":2") == 0 ||
       strstr(json, "\"deny_missing_process_count\":1") == 0 ||
       strstr(json, "\"deny_missing_capability_count\":2") == 0 ||
       strstr(json, "\"deny_policy_gate_count\":1") == 0 ||
       strstr(json, "\"decision_cache_hits\":1") == 0 ||
-      strstr(json, "\"decision_cache_misses\":6") == 0 ||
+      strstr(json, "\"decision_cache_misses\":8") == 0 ||
       strstr(json, "\"process_lookup_cache_hits\":") == 0 ||
       strstr(json, "\"process_lookup_cache_misses\":") == 0 ||
       strstr(json, "\"rule_lookup_cache_hits\":") == 0 ||
       strstr(json, "\"rule_lookup_cache_misses\":") == 0 ||
+      strstr(json, "\"removed_rule_count\":1") == 0 ||
       strstr(json, "\"syscall_id\":100") == 0 ||
       strstr(json, "\"process_id\":7001") == 0) {
     fprintf(stderr, "syscall gate snapshot mismatch: %s\n", json);
@@ -904,6 +993,82 @@ static int test_memory_zone_accounting_and_reclaim_hooks(void) {
   }
   if (aegis_memory_zone_snapshot_json(&table, tiny, sizeof(tiny)) >= 0) {
     fprintf(stderr, "expected tiny memory zone snapshot failure\n");
+    return 1;
+  }
+  return 0;
+}
+
+static int test_scheduler_wait_latency_clamp_and_turbo_adapt(void) {
+  aegis_scheduler_t scheduler;
+  uint32_t pid = 0u;
+  int i;
+  aegis_scheduler_init(&scheduler);
+  aegis_scheduler_enable_turbo(&scheduler, 1u);
+  for (i = 0; i < 26; ++i) {
+    if (aegis_scheduler_add_with_priority(&scheduler, (uint32_t)(12000u + (uint32_t)i),
+                                          (uint8_t)((i % 3) + 1)) != 0) {
+      fprintf(stderr, "wait clamp/turbo adapt add failed\n");
+      return 1;
+    }
+  }
+  scheduler.scheduler_ticks = 10u;
+  for (i = 0; i < 26; ++i) {
+    scheduler.enqueued_tick[i] = 50u;
+  }
+  if (aegis_scheduler_next(&scheduler, &pid) != 0) {
+    fprintf(stderr, "wait clamp/turbo adapt next failed\n");
+    return 1;
+  }
+  if (scheduler.wait_latency_clamp_events == 0u) {
+    fprintf(stderr, "wait clamp counter expected > 0\n");
+    return 1;
+  }
+  if (scheduler.turbo_reuse_budget_adaptations == 0u ||
+      scheduler.turbo_candidate_cache_max_reuse < 2u) {
+    fprintf(stderr, "turbo reuse adaptive tuning expected adjustment\n");
+    return 1;
+  }
+  return 0;
+}
+
+static int test_lookup_cache_cross_module_stress(void) {
+  aegis_namespace_table_t namespaces;
+  aegis_ipc_channel_table_t ipc;
+  aegis_memory_zone_table_t mem;
+  uint32_t ns = 0u;
+  uint32_t local = 0u;
+  uint32_t global = 0u;
+  uint8_t visible = 0u;
+  uint8_t accepted = 0u;
+  int i;
+  aegis_namespace_table_init(&namespaces);
+  aegis_ipc_channel_table_init(&ipc);
+  aegis_memory_zone_table_init(&mem);
+  if (aegis_namespace_create(&namespaces, 0u, &ns) != 0 ||
+      aegis_namespace_attach_process(&namespaces, 9101u, ns, &local) != 0) {
+    fprintf(stderr, "cross-module namespace setup failed\n");
+    return 1;
+  }
+  if (aegis_ipc_channel_configure(&ipc, 91u, 1024u) != 0 ||
+      aegis_memory_zone_configure(&mem, 91u, AEGIS_MEMORY_ZONE_USER, 4096u) != 0) {
+    fprintf(stderr, "cross-module ipc/memory setup failed\n");
+    return 1;
+  }
+  for (i = 0; i < 16; ++i) {
+    if (aegis_namespace_translate_local_to_global(&namespaces, ns, local, &global) != 0 ||
+        global != 9101u ||
+        aegis_namespace_can_inspect(&namespaces, 9101u, 9101u, &visible) != 0 ||
+        visible != 1u ||
+        aegis_ipc_channel_reserve_send(&ipc, 91u, 16u, &accepted) < 0 ||
+        aegis_memory_zone_charge(&mem, 91u, 8u, &accepted) < 0) {
+      fprintf(stderr, "cross-module mixed operation failed\n");
+      return 1;
+    }
+  }
+  if (namespaces.lookup_cache_hits == 0u ||
+      ipc.lookup_cache_hits == 0u ||
+      mem.lookup_cache_hits == 0u) {
+    fprintf(stderr, "cross-module expected cache hits in all modules\n");
     return 1;
   }
   return 0;
@@ -1416,6 +1581,8 @@ static int test_scheduler_fairness_snapshot_json_endpoint(void) {
   }
   if (strstr(json, "\"schema_version\":1") == 0 ||
       strstr(json, "\"queue_depth\":3") == 0 ||
+      strstr(json, "\"pid_lookup_cache_hits\":") == 0 ||
+      strstr(json, "\"bulk_apply_calls\":") == 0 ||
       strstr(json, "\"process_id\":9801") == 0 ||
       strstr(json, "\"dispatch_share_bps\":") == 0 ||
       strstr(json, "\"wait_ticks_total\":") == 0) {
@@ -1648,6 +1815,9 @@ int main(void) {
   if (test_vm_region_split_and_permission_update() != 0) {
     return 1;
   }
+  if (test_vm_query_cache_invalidation_after_mutation() != 0) {
+    return 1;
+  }
   if (test_ipc_envelope_format_helpers() != 0) {
     return 1;
   }
@@ -1687,10 +1857,16 @@ int main(void) {
   if (test_scheduler_bulk_apply_api_and_metrics() != 0) {
     return 1;
   }
+  if (test_scheduler_bulk_apply_rejection_paths() != 0) {
+    return 1;
+  }
   if (test_scheduler_priority_count_tracking_after_reprioritize() != 0) {
     return 1;
   }
   if (test_scheduler_turbo_candidate_cache_reuse() != 0) {
+    return 1;
+  }
+  if (test_scheduler_wait_latency_clamp_and_turbo_adapt() != 0) {
     return 1;
   }
   if (test_namespace_isolation_simulator() != 0) {
@@ -1703,6 +1879,9 @@ int main(void) {
     return 1;
   }
   if (test_memory_zone_accounting_and_reclaim_hooks() != 0) {
+    return 1;
+  }
+  if (test_lookup_cache_cross_module_stress() != 0) {
     return 1;
   }
   if (test_scheduler_metrics() != 0) {


### PR DESCRIPTION
## Summary\n- enhance turbo scheduling algorithm with adaptive reuse-budget tuning and stronger runaway-dispatch penalties\n- harden wait-latency accounting with non-monotonic tick safety clamps\n- extend scheduler bulk API telemetry (unknown ops, dropped results) and validate rejection paths\n- enrich fairness/admission snapshots with cache+bulk tuning signals\n- add syscall rule removal API and snapshot policy-churn telemetry\n- add VM cache invalidation regressions and cross-module lookup-cache stress coverage\n- refresh top-level and kernel docs for new optimization paths\n\n## Validation\n- python scripts/run_clang_suite.py\n- python -m pytest -q\n- python scripts/validate_packages.py\n\nCloses #176\nCloses #177\nCloses #178\nCloses #179\nCloses #180\nCloses #181\nCloses #182\nCloses #183\nCloses #184\nCloses #185\nCloses #186\nCloses #187\nCloses #188\nCloses #189\nCloses #190