### PR TITLE
feat: checkpoint + secure-time cache and telemetry speed batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ This repository contains:
 - Wait-latency safety clamps and enriched fairness/admission snapshot telemetry for tuning pipelines.
 - IPC channel and memory zone lookup-cache fast paths to reduce hot-ID linear scan overhead.
 - Syscall rule removal API with policy-churn telemetry (`removed_rule_count`) in syscall snapshots.
+- Checkpoint subsystem runtime/entry PID lookup-cache fast paths with expanded recovery counters.
+- Secure-time nonce lookup-cache telemetry and drift-budget clamp-event tracking for attestation observability.
 - Namespace translation lookup-cache and scheduler percentile-selection fast path for lower runtime metrics overhead.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -44,8 +44,13 @@ Kernel direction, interfaces, and implementation notes live here.
 - `aegis_process_checkpoint_table_t`: process checkpoint capture/restore for recovery workflows.
   - supports process runtime registration and per-reason checkpoint capture.
   - supports checkpoint restore with epoch verification and failure counters.
+  - includes runtime/checkpoint PID lookup-cache fast paths with hit/miss telemetry.
+  - includes overwrite/query-miss/epoch-mismatch/replay-applied counters for recovery observability.
   - exposes snapshot JSON endpoint with entry-level checkpoint metadata.
   - supports disk-backed journal save and boot-time replay for crash recovery.
+- `aegis_secure_time_attestor_t`:
+  - includes nonce lookup-cache fast path for repeated nonce-replay checks.
+  - tracks drift-budget clamp events and nonce cache hit/miss telemetry in snapshot JSON.
 - `aegis_syscall_gate_matrix_t`: syscall capability enforcement matrix.
   - includes decision-cache fast path for hot process/syscall pairs.
   - includes process/rule lookup-cache fast paths to reduce repeated linear scans.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -339,6 +339,20 @@ typedef struct {
   uint64_t capture_count;
   uint64_t restore_count;
   uint64_t restore_failures;
+  uint32_t runtime_lookup_cache_process_id;
+  uint16_t runtime_lookup_cache_index;
+  uint8_t runtime_lookup_cache_valid;
+  uint64_t runtime_lookup_cache_hits;
+  uint64_t runtime_lookup_cache_misses;
+  uint32_t checkpoint_lookup_cache_process_id;
+  uint16_t checkpoint_lookup_cache_index;
+  uint8_t checkpoint_lookup_cache_valid;
+  uint64_t checkpoint_lookup_cache_hits;
+  uint64_t checkpoint_lookup_cache_misses;
+  uint64_t capture_overwrite_existing;
+  uint64_t restore_epoch_mismatch_failures;
+  uint64_t query_misses;
+  uint64_t journal_replay_entries_applied;
 } aegis_process_checkpoint_table_t;
 
 typedef struct {
@@ -354,6 +368,11 @@ typedef struct {
   char recent_nonces[8][AEGIS_TIME_ATTEST_NONCE_MAX + 1u];
   uint8_t recent_nonce_count;
   uint8_t recent_nonce_head;
+  char nonce_lookup_cache[AEGIS_TIME_ATTEST_NONCE_MAX + 1u];
+  uint8_t nonce_lookup_cache_valid;
+  uint64_t nonce_lookup_cache_hits;
+  uint64_t nonce_lookup_cache_misses;
+  uint64_t drift_budget_clamp_events;
   uint8_t initialized;
 } aegis_secure_time_attestor_t;
 

--- a/kernel/src/process_checkpoint.c
+++ b/kernel/src/process_checkpoint.c
@@ -11,10 +11,23 @@ static int runtime_index_for_pid(const aegis_process_checkpoint_table_t *table,
   if (table == 0 || index_out == 0 || process_id == 0u) {
     return 0;
   }
+  if (table->runtime_lookup_cache_valid != 0u &&
+      table->runtime_lookup_cache_process_id == process_id &&
+      table->runtime_lookup_cache_index < AEGIS_PROCESS_CHECKPOINT_CAPACITY &&
+      table->runtime_states[table->runtime_lookup_cache_index].active != 0u &&
+      table->runtime_states[table->runtime_lookup_cache_index].process_id == process_id) {
+    *index_out = table->runtime_lookup_cache_index;
+    ((aegis_process_checkpoint_table_t *)table)->runtime_lookup_cache_hits += 1u;
+    return 1;
+  }
+  ((aegis_process_checkpoint_table_t *)table)->runtime_lookup_cache_misses += 1u;
   for (i = 0; i < AEGIS_PROCESS_CHECKPOINT_CAPACITY; ++i) {
     if (table->runtime_states[i].active != 0u &&
         table->runtime_states[i].process_id == process_id) {
       *index_out = i;
+      ((aegis_process_checkpoint_table_t *)table)->runtime_lookup_cache_valid = 1u;
+      ((aegis_process_checkpoint_table_t *)table)->runtime_lookup_cache_process_id = process_id;
+      ((aegis_process_checkpoint_table_t *)table)->runtime_lookup_cache_index = (uint16_t)i;
       return 1;
     }
   }
@@ -28,10 +41,23 @@ static int checkpoint_index_for_pid(const aegis_process_checkpoint_table_t *tabl
   if (table == 0 || index_out == 0 || process_id == 0u) {
     return 0;
   }
+  if (table->checkpoint_lookup_cache_valid != 0u &&
+      table->checkpoint_lookup_cache_process_id == process_id &&
+      table->checkpoint_lookup_cache_index < AEGIS_PROCESS_CHECKPOINT_CAPACITY &&
+      table->checkpoints[table->checkpoint_lookup_cache_index].valid != 0u &&
+      table->checkpoints[table->checkpoint_lookup_cache_index].process_id == process_id) {
+    *index_out = table->checkpoint_lookup_cache_index;
+    ((aegis_process_checkpoint_table_t *)table)->checkpoint_lookup_cache_hits += 1u;
+    return 1;
+  }
+  ((aegis_process_checkpoint_table_t *)table)->checkpoint_lookup_cache_misses += 1u;
   for (i = 0; i < AEGIS_PROCESS_CHECKPOINT_CAPACITY; ++i) {
     if (table->checkpoints[i].valid != 0u &&
         table->checkpoints[i].process_id == process_id) {
       *index_out = i;
+      ((aegis_process_checkpoint_table_t *)table)->checkpoint_lookup_cache_valid = 1u;
+      ((aegis_process_checkpoint_table_t *)table)->checkpoint_lookup_cache_process_id = process_id;
+      ((aegis_process_checkpoint_table_t *)table)->checkpoint_lookup_cache_index = (uint16_t)i;
       return 1;
     }
   }
@@ -75,6 +101,20 @@ void aegis_process_checkpoint_table_init(aegis_process_checkpoint_table_t *table
   table->capture_count = 0u;
   table->restore_count = 0u;
   table->restore_failures = 0u;
+  table->runtime_lookup_cache_process_id = 0u;
+  table->runtime_lookup_cache_index = 0u;
+  table->runtime_lookup_cache_valid = 0u;
+  table->runtime_lookup_cache_hits = 0u;
+  table->runtime_lookup_cache_misses = 0u;
+  table->checkpoint_lookup_cache_process_id = 0u;
+  table->checkpoint_lookup_cache_index = 0u;
+  table->checkpoint_lookup_cache_valid = 0u;
+  table->checkpoint_lookup_cache_hits = 0u;
+  table->checkpoint_lookup_cache_misses = 0u;
+  table->capture_overwrite_existing = 0u;
+  table->restore_epoch_mismatch_failures = 0u;
+  table->query_misses = 0u;
+  table->journal_replay_entries_applied = 0u;
   for (i = 0; i < AEGIS_PROCESS_CHECKPOINT_CAPACITY; ++i) {
     memset(&table->runtime_states[i], 0, sizeof(table->runtime_states[i]));
     memset(&table->checkpoints[i], 0, sizeof(table->checkpoints[i]));
@@ -91,6 +131,9 @@ int aegis_process_checkpoint_register_runtime(aegis_process_checkpoint_table_t *
   if (runtime_index_for_pid(table, state->process_id, &idx)) {
     table->runtime_states[idx] = *state;
     table->runtime_states[idx].active = 1u;
+    table->runtime_lookup_cache_valid = 1u;
+    table->runtime_lookup_cache_process_id = state->process_id;
+    table->runtime_lookup_cache_index = (uint16_t)idx;
     return 0;
   }
   for (i = 0; i < AEGIS_PROCESS_CHECKPOINT_CAPACITY; ++i) {
@@ -99,6 +142,9 @@ int aegis_process_checkpoint_register_runtime(aegis_process_checkpoint_table_t *
     }
     table->runtime_states[i] = *state;
     table->runtime_states[i].active = 1u;
+    table->runtime_lookup_cache_valid = 1u;
+    table->runtime_lookup_cache_process_id = state->process_id;
+    table->runtime_lookup_cache_index = (uint16_t)i;
     return 0;
   }
   return -1;
@@ -133,6 +179,9 @@ int aegis_process_checkpoint_capture(aegis_process_checkpoint_table_t *table,
       return -1;
     }
   }
+  else {
+    table->capture_overwrite_existing += 1u;
+  }
   entry = &table->checkpoints[checkpoint_idx];
   entry->process_id = process_id;
   entry->checkpoint_epoch = table->next_epoch;
@@ -149,6 +198,9 @@ int aegis_process_checkpoint_capture(aegis_process_checkpoint_table_t *table,
   *checkpoint_epoch_out = table->next_epoch;
   table->next_epoch += 1u;
   table->capture_count += 1u;
+  table->checkpoint_lookup_cache_valid = 1u;
+  table->checkpoint_lookup_cache_process_id = process_id;
+  table->checkpoint_lookup_cache_index = (uint16_t)checkpoint_idx;
   return 0;
 }
 
@@ -168,6 +220,7 @@ int aegis_process_checkpoint_restore(aegis_process_checkpoint_table_t *table,
       table->checkpoints[checkpoint_idx].checkpoint_epoch != expected_epoch) {
     table->checkpoints[checkpoint_idx].last_restore_status = 0u;
     table->restore_failures += 1u;
+    table->restore_epoch_mismatch_failures += 1u;
     return -1;
   }
   *restored_state_out = table->checkpoints[checkpoint_idx].state;
@@ -185,6 +238,7 @@ int aegis_process_checkpoint_query(const aegis_process_checkpoint_table_t *table
     return -1;
   }
   if (!checkpoint_index_for_pid(table, process_id, &checkpoint_idx)) {
+    ((aegis_process_checkpoint_table_t *)table)->query_misses += 1u;
     return -1;
   }
   *entry_out = table->checkpoints[checkpoint_idx];
@@ -204,10 +258,25 @@ int aegis_process_checkpoint_snapshot_json(const aegis_process_checkpoint_table_
   written = snprintf(out,
                      out_size,
                      "{\"schema_version\":1,\"capture_count\":%llu,\"restore_count\":%llu,"
-                     "\"restore_failures\":%llu,\"entries\":[",
+                     "\"restore_failures\":%llu,\"runtime_lookup_cache_hits\":%llu,"
+                     "\"runtime_lookup_cache_misses\":%llu,"
+                     "\"checkpoint_lookup_cache_hits\":%llu,"
+                     "\"checkpoint_lookup_cache_misses\":%llu,"
+                     "\"capture_overwrite_existing\":%llu,"
+                     "\"restore_epoch_mismatch_failures\":%llu,"
+                     "\"query_misses\":%llu,\"journal_replay_entries_applied\":%llu,"
+                     "\"entries\":[",
                      (unsigned long long)table->capture_count,
                      (unsigned long long)table->restore_count,
-                     (unsigned long long)table->restore_failures);
+                     (unsigned long long)table->restore_failures,
+                     (unsigned long long)table->runtime_lookup_cache_hits,
+                     (unsigned long long)table->runtime_lookup_cache_misses,
+                     (unsigned long long)table->checkpoint_lookup_cache_hits,
+                     (unsigned long long)table->checkpoint_lookup_cache_misses,
+                     (unsigned long long)table->capture_overwrite_existing,
+                     (unsigned long long)table->restore_epoch_mismatch_failures,
+                     (unsigned long long)table->query_misses,
+                     (unsigned long long)table->journal_replay_entries_applied);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }
@@ -424,6 +493,10 @@ int aegis_process_checkpoint_journal_replay(aegis_process_checkpoint_table_t *ta
         return -1;
       }
     }
+    table->journal_replay_entries_applied += 1u;
+    table->checkpoint_lookup_cache_valid = 1u;
+    table->checkpoint_lookup_cache_process_id = entry->process_id;
+    table->checkpoint_lookup_cache_index = (uint16_t)checkpoint_cursor;
     if (entry->checkpoint_epoch > max_epoch_seen) {
       max_epoch_seen = entry->checkpoint_epoch;
     }

--- a/kernel/src/secure_time_attestation.c
+++ b/kernel/src/secure_time_attestation.c
@@ -12,8 +12,19 @@ static int nonce_seen(const aegis_secure_time_attestor_t *attestor, const char *
   if (attestor == 0 || nonce == 0 || nonce[0] == '\0') {
     return 0;
   }
+  if (attestor->nonce_lookup_cache_valid != 0u &&
+      strcmp(attestor->nonce_lookup_cache, nonce) == 0) {
+    ((aegis_secure_time_attestor_t *)attestor)->nonce_lookup_cache_hits += 1u;
+    return 1;
+  }
+  ((aegis_secure_time_attestor_t *)attestor)->nonce_lookup_cache_misses += 1u;
   for (i = 0; i < attestor->recent_nonce_count && i < 8u; ++i) {
     if (strcmp(attestor->recent_nonces[i], nonce) == 0) {
+      snprintf(((aegis_secure_time_attestor_t *)attestor)->nonce_lookup_cache,
+               sizeof(((aegis_secure_time_attestor_t *)attestor)->nonce_lookup_cache),
+               "%s",
+               nonce);
+      ((aegis_secure_time_attestor_t *)attestor)->nonce_lookup_cache_valid = 1u;
       return 1;
     }
   }
@@ -31,6 +42,8 @@ static void nonce_record(aegis_secure_time_attestor_t *attestor, const char *non
   if (attestor->recent_nonce_count < 8u) {
     attestor->recent_nonce_count += 1u;
   }
+  snprintf(attestor->nonce_lookup_cache, sizeof(attestor->nonce_lookup_cache), "%s", nonce);
+  attestor->nonce_lookup_cache_valid = 1u;
 }
 
 void aegis_secure_time_attestor_init(aegis_secure_time_attestor_t *attestor,
@@ -93,7 +106,13 @@ int aegis_secure_time_attest(aegis_secure_time_attestor_t *attestor,
   }
 
   delta_monotonic = observed_monotonic_tick - attestor->last_monotonic_tick;
-  budget_seconds = (delta_monotonic * attestor->drift_budget_ppm) / 1000000u;
+  if (delta_monotonic != 0u &&
+      attestor->drift_budget_ppm > (UINT64_MAX / delta_monotonic)) {
+    budget_seconds = UINT64_MAX / 1000000u;
+    attestor->drift_budget_clamp_events += 1u;
+  } else {
+    budget_seconds = (delta_monotonic * attestor->drift_budget_ppm) / 1000000u;
+  }
   if (budget_seconds == 0u && delta_monotonic > 0u) {
     budget_seconds = 1u;
   }
@@ -165,7 +184,8 @@ int aegis_secure_time_attestor_snapshot_json(const aegis_secure_time_attestor_t 
                      "\"last_monotonic_tick\":%llu,\"drift_budget_ppm\":%llu,"
                      "\"attestations_ok\":%llu,\"attestations_failed\":%llu,"
                      "\"rollback_detected\":%llu,\"drift_violations\":%llu,"
-                     "\"nonce_replay_detected\":%llu}",
+                     "\"nonce_replay_detected\":%llu,\"nonce_lookup_cache_hits\":%llu,"
+                     "\"nonce_lookup_cache_misses\":%llu,\"drift_budget_clamp_events\":%llu}",
                      (unsigned int)attestor->boot_id,
                      (unsigned long long)attestor->last_wallclock_epoch,
                      (unsigned long long)attestor->last_monotonic_tick,
@@ -174,7 +194,10 @@ int aegis_secure_time_attestor_snapshot_json(const aegis_secure_time_attestor_t 
                      (unsigned long long)attestor->attestations_failed,
                      (unsigned long long)attestor->rollback_detected,
                      (unsigned long long)attestor->drift_violations,
-                     (unsigned long long)attestor->nonce_replay_detected);
+                     (unsigned long long)attestor->nonce_replay_detected,
+                     (unsigned long long)attestor->nonce_lookup_cache_hits,
+                     (unsigned long long)attestor->nonce_lookup_cache_misses,
+                     (unsigned long long)attestor->drift_budget_clamp_events);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -1666,6 +1666,14 @@ static int test_process_checkpoint_restore_scaffold(void) {
       strstr(json, "\"capture_count\":1") == 0 ||
       strstr(json, "\"restore_count\":1") == 0 ||
       strstr(json, "\"restore_failures\":1") == 0 ||
+      strstr(json, "\"runtime_lookup_cache_hits\":") == 0 ||
+      strstr(json, "\"runtime_lookup_cache_misses\":") == 0 ||
+      strstr(json, "\"checkpoint_lookup_cache_hits\":") == 0 ||
+      strstr(json, "\"checkpoint_lookup_cache_misses\":") == 0 ||
+      strstr(json, "\"capture_overwrite_existing\":0") == 0 ||
+      strstr(json, "\"restore_epoch_mismatch_failures\":1") == 0 ||
+      strstr(json, "\"query_misses\":0") == 0 ||
+      strstr(json, "\"journal_replay_entries_applied\":0") == 0 ||
       strstr(json, "\"process_id\":11001") == 0 ||
       strstr(json, "\"tag\":\"pre-update\"") == 0) {
     fprintf(stderr, "checkpoint snapshot json mismatch: %s\n", json);
@@ -1740,12 +1748,65 @@ static int test_process_checkpoint_journal_persistence_and_replay(void) {
   if (aegis_process_checkpoint_snapshot_json(&replayed, json, sizeof(json)) <= 0 ||
       strstr(json, "\"capture_count\":1") == 0 ||
       strstr(json, "\"restore_count\":1") == 0 ||
+      strstr(json, "\"journal_replay_entries_applied\":1") == 0 ||
       strstr(json, "\"tag\":\"crash-recovery\"") == 0) {
     fprintf(stderr, "checkpoint journal replay snapshot mismatch: %s\n", json);
     remove(journal_path);
     return 1;
   }
   remove(journal_path);
+  return 0;
+}
+
+static int test_process_checkpoint_cache_and_counter_paths(void) {
+  aegis_process_checkpoint_table_t table;
+  aegis_process_runtime_state_t runtime;
+  aegis_process_checkpoint_entry_t entry;
+  uint64_t epoch = 0u;
+  char json[4096];
+  memset(&runtime, 0, sizeof(runtime));
+  memset(&entry, 0, sizeof(entry));
+  aegis_process_checkpoint_table_init(&table);
+  runtime.process_id = 13001u;
+  runtime.namespace_id = 55u;
+  runtime.thread_count = 1u;
+  runtime.vm_bytes = 4096u;
+  runtime.capability_mask = 0x1u;
+  runtime.policy_revision = 1u;
+  runtime.scheduler_tick = 12u;
+  runtime.active = 1u;
+  if (aegis_process_checkpoint_register_runtime(&table, &runtime) != 0) {
+    fprintf(stderr, "checkpoint cache/counter register runtime failed\n");
+    return 1;
+  }
+  if (aegis_process_checkpoint_capture(&table,
+                                       runtime.process_id,
+                                       AEGIS_CHECKPOINT_REASON_MANUAL,
+                                       13u,
+                                       "first",
+                                       &epoch) != 0) {
+    fprintf(stderr, "checkpoint cache/counter first capture failed\n");
+    return 1;
+  }
+  if (aegis_process_checkpoint_capture(&table,
+                                       runtime.process_id,
+                                       AEGIS_CHECKPOINT_REASON_PRE_UPDATE,
+                                       14u,
+                                       "overwrite",
+                                       &epoch) != 0) {
+    fprintf(stderr, "checkpoint cache/counter overwrite capture failed\n");
+    return 1;
+  }
+  if (aegis_process_checkpoint_query(&table, 99999u, &entry) == 0) {
+    fprintf(stderr, "checkpoint cache/counter expected query miss\n");
+    return 1;
+  }
+  if (aegis_process_checkpoint_snapshot_json(&table, json, sizeof(json)) <= 0 ||
+      strstr(json, "\"capture_overwrite_existing\":1") == 0 ||
+      strstr(json, "\"query_misses\":1") == 0) {
+    fprintf(stderr, "checkpoint cache/counter snapshot mismatch: %s\n", json);
+    return 1;
+  }
   return 0;
 }
 
@@ -1798,7 +1859,10 @@ static int test_secure_time_source_attestation(void) {
       strstr(snapshot_json, "\"schema_version\":1") == 0 ||
       strstr(snapshot_json, "\"attestations_ok\":1") == 0 ||
       strstr(snapshot_json, "\"attestations_failed\":3") == 0 ||
-      strstr(snapshot_json, "\"nonce_replay_detected\":1") == 0) {
+      strstr(snapshot_json, "\"nonce_replay_detected\":1") == 0 ||
+      strstr(snapshot_json, "\"nonce_lookup_cache_hits\":1") == 0 ||
+      strstr(snapshot_json, "\"nonce_lookup_cache_misses\":3") == 0 ||
+      strstr(snapshot_json, "\"drift_budget_clamp_events\":0") == 0) {
     fprintf(stderr, "secure time snapshot mismatch: %s\n", snapshot_json);
     return 1;
   }
@@ -1918,6 +1982,9 @@ int main(void) {
     return 1;
   }
   if (test_process_checkpoint_journal_persistence_and_replay() != 0) {
+    return 1;
+  }
+  if (test_process_checkpoint_cache_and_counter_paths() != 0) {
     return 1;
   }
   if (test_secure_time_source_attestation() != 0) {


### PR DESCRIPTION
## Summary\n- add checkpoint runtime/checkpoint PID lookup-cache fast paths with hit/miss telemetry\n- add checkpoint counters: overwrite-existing, epoch-mismatch-failures, query-misses, replay-applied entries\n- expand checkpoint snapshot JSON with new cache/counter telemetry\n- add secure-time nonce lookup-cache fast path and telemetry in snapshot\n- add secure-time drift-budget clamp-event telemetry\n- extend regression tests for checkpoint/secure-time/cross-path behavior and tiny-buffer checks\n- refresh docs for new optimization surfaces\n\n## Validation\n- python scripts/run_clang_suite.py\n- python -m pytest -q\n- python scripts/validate_packages.py\n\nCloses #192\nCloses #193\nCloses #194\nCloses #195\nCloses #196\nCloses #197\nCloses #198\nCloses #199\nCloses #200\nCloses #201\nCloses #202\nCloses #203\nCloses #204\nCloses #205\nCloses #206