### PR TITLE
Namespace/IPC/Memory error telemetry + regression coverage (#208-#222)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ This repository contains:
 - Checkpoint subsystem runtime/entry PID lookup-cache fast paths with expanded recovery counters.
 - Secure-time nonce lookup-cache telemetry and drift-budget clamp-event tracking for attestation observability.
 - Namespace translation lookup-cache and scheduler percentile-selection fast path for lower runtime metrics overhead.
+- Namespace attach/detach/translate/inspect failure counters plus cache-invalidation telemetry in namespace snapshots.
+- IPC unknown-channel request and drain-underflow clamp telemetry in channel snapshots.
+- Memory unknown-zone request, release-underflow clamp, and reclaim-shortfall telemetry in zone snapshots.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -59,6 +59,10 @@ Kernel direction, interfaces, and implementation notes live here.
 - `aegis_ipc_channel_table_t` and `aegis_memory_zone_table_t`:
   - include lookup-cache fast paths for hot channel/zone IDs.
   - expose lookup-cache hit/miss telemetry in JSON snapshots.
+  - include IPC unknown-channel and drain-underflow clamp counters in snapshot telemetry.
+  - include memory unknown-zone, release-underflow clamp, and reclaim-shortfall counters.
 - `aegis_namespace_table_t`:
   - includes lookup-cache fast paths for local/global pid translation.
   - exposes lookup-cache hit/miss telemetry in namespace snapshot JSON.
+  - tracks attach/detach/translate/inspect failure counters for error-path observability.
+  - tracks namespace cache invalidation count to expose mutation churn.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -267,6 +267,8 @@ typedef struct {
   uint8_t lookup_cache_valid;
   uint64_t lookup_cache_hits;
   uint64_t lookup_cache_misses;
+  uint64_t unknown_channel_requests;
+  uint64_t drain_underflow_clamps;
 } aegis_ipc_channel_table_t;
 
 typedef enum {
@@ -300,6 +302,9 @@ typedef struct {
   uint8_t lookup_cache_valid;
   uint64_t lookup_cache_hits;
   uint64_t lookup_cache_misses;
+  uint64_t unknown_zone_requests;
+  uint64_t release_underflow_clamps;
+  uint64_t reclaim_shortfall_events;
 } aegis_memory_zone_table_t;
 
 typedef enum {
@@ -418,6 +423,12 @@ typedef struct {
   uint8_t lookup_cache_valid;
   uint64_t lookup_cache_hits;
   uint64_t lookup_cache_misses;
+  uint64_t attach_failures;
+  uint64_t detach_failures;
+  uint64_t translate_local_failures;
+  uint64_t translate_global_failures;
+  uint64_t inspect_failures;
+  uint64_t cache_invalidations;
 } aegis_namespace_table_t;
 
 int aegis_kernel_boot_check(void);

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -1943,6 +1943,12 @@ void aegis_namespace_table_init(aegis_namespace_table_t *table) {
   table->lookup_cache_valid = 0u;
   table->lookup_cache_hits = 0u;
   table->lookup_cache_misses = 0u;
+  table->attach_failures = 0u;
+  table->detach_failures = 0u;
+  table->translate_local_failures = 0u;
+  table->translate_global_failures = 0u;
+  table->inspect_failures = 0u;
+  table->cache_invalidations = 0u;
   for (i = 0; i < AEGIS_NAMESPACE_CAPACITY; ++i) {
     table->namespaces[i].namespace_id = 0u;
     table->namespaces[i].parent_namespace_id = 0u;
@@ -1974,6 +1980,7 @@ int aegis_namespace_create(aegis_namespace_table_t *table,
   }
   if (parent_namespace_id != 0u &&
       !namespace_find_index(table, parent_namespace_id, &parent_index)) {
+    table->detach_failures += 1u;
     return -1;
   }
   for (i = 0; i < AEGIS_NAMESPACE_CAPACITY; ++i) {
@@ -1989,6 +1996,7 @@ int aegis_namespace_create(aegis_namespace_table_t *table,
     table->next_namespace_id += 1u;
     table->namespace_count += 1u;
     table->lookup_cache_valid = 0u;
+    table->cache_invalidations += 1u;
     return 0;
   }
   (void)parent_index;
@@ -1999,20 +2007,26 @@ int aegis_namespace_destroy(aegis_namespace_table_t *table, uint32_t namespace_i
   size_t ns_index = 0u;
   size_t i;
   if (table == 0 || namespace_id == 0u || namespace_id == 1u) {
+    if (table != 0) {
+      table->detach_failures += 1u;
+    }
     return -1;
   }
   if (!namespace_find_index(table, namespace_id, &ns_index)) {
+    table->detach_failures += 1u;
     return -1;
   }
   for (i = 0; i < AEGIS_NAMESPACE_PROCESS_CAPACITY; ++i) {
     if (table->processes[i].active != 0u &&
         table->processes[i].namespace_id == namespace_id) {
+      table->detach_failures += 1u;
       return -1;
     }
   }
   for (i = 0; i < AEGIS_NAMESPACE_CAPACITY; ++i) {
     if (table->namespaces[i].active != 0u &&
         table->namespaces[i].parent_namespace_id == namespace_id) {
+      table->detach_failures += 1u;
       return -1;
     }
   }
@@ -2025,6 +2039,7 @@ int aegis_namespace_destroy(aegis_namespace_table_t *table, uint32_t namespace_i
     table->namespace_count -= 1u;
   }
   table->lookup_cache_valid = 0u;
+  table->cache_invalidations += 1u;
   return 0;
 }
 
@@ -2037,12 +2052,17 @@ int aegis_namespace_attach_process(aegis_namespace_table_t *table,
   size_t i;
   uint32_t local_pid;
   if (table == 0 || process_id == 0u || local_pid_out == 0) {
+    if (table != 0) {
+      table->attach_failures += 1u;
+    }
     return -1;
   }
   if (!namespace_find_index(table, namespace_id, &ns_index)) {
+    table->attach_failures += 1u;
     return -1;
   }
   if (namespace_process_find_by_global(table, process_id, &existing)) {
+    table->attach_failures += 1u;
     return -1;
   }
   local_pid = table->namespaces[ns_index].local_pid_counter + 1u;
@@ -2065,6 +2085,7 @@ int aegis_namespace_attach_process(aegis_namespace_table_t *table,
     table->lookup_cache_index = (uint16_t)i;
     return 0;
   }
+  table->attach_failures += 1u;
   return -1;
 }
 
@@ -2072,12 +2093,17 @@ int aegis_namespace_detach_process(aegis_namespace_table_t *table, uint32_t proc
   size_t proc_index = 0u;
   size_t ns_index = 0u;
   if (table == 0 || process_id == 0u) {
+    if (table != 0) {
+      table->detach_failures += 1u;
+    }
     return -1;
   }
   if (!namespace_process_find_by_global(table, process_id, &proc_index)) {
+    table->detach_failures += 1u;
     return -1;
   }
   if (!namespace_find_index(table, table->processes[proc_index].namespace_id, &ns_index)) {
+    table->detach_failures += 1u;
     return -1;
   }
   table->processes[proc_index].active = 0u;
@@ -2091,6 +2117,7 @@ int aegis_namespace_detach_process(aegis_namespace_table_t *table, uint32_t proc
     table->process_count -= 1u;
   }
   table->lookup_cache_valid = 0u;
+  table->cache_invalidations += 1u;
   return 0;
 }
 
@@ -2106,6 +2133,7 @@ int aegis_namespace_translate_local_to_global(const aegis_namespace_table_t *tab
     *process_id_out = table->processes[i].process_id;
     return 0;
   }
+  ((aegis_namespace_table_t *)table)->translate_local_failures += 1u;
   return -1;
 }
 
@@ -2122,6 +2150,7 @@ int aegis_namespace_translate_global_to_local(const aegis_namespace_table_t *tab
     *local_pid_out = table->processes[i].local_pid;
     return 0;
   }
+  ((aegis_namespace_table_t *)table)->translate_global_failures += 1u;
   return -1;
 }
 
@@ -2137,6 +2166,7 @@ int aegis_namespace_can_inspect(const aegis_namespace_table_t *table,
   *allowed_out = 0u;
   if (!namespace_process_find_by_global(table, requester_process_id, &req_index) ||
       !namespace_process_find_by_global(table, target_process_id, &tgt_index)) {
+    ((aegis_namespace_table_t *)table)->inspect_failures += 1u;
     return 0;
   }
   if (table->processes[req_index].namespace_id == table->processes[tgt_index].namespace_id) {
@@ -2160,11 +2190,20 @@ int aegis_namespace_snapshot_json(const aegis_namespace_table_t *table,
                      out_size,
                      "{\"schema_version\":1,\"namespace_count\":%llu,\"process_count\":%llu,"
                      "\"lookup_cache_hits\":%llu,\"lookup_cache_misses\":%llu,"
+                     "\"attach_failures\":%llu,\"detach_failures\":%llu,"
+                     "\"translate_local_failures\":%llu,\"translate_global_failures\":%llu,"
+                     "\"inspect_failures\":%llu,\"cache_invalidations\":%llu,"
                      "\"namespaces\":[",
                      (unsigned long long)table->namespace_count,
                      (unsigned long long)table->process_count,
                      (unsigned long long)table->lookup_cache_hits,
-                     (unsigned long long)table->lookup_cache_misses);
+                     (unsigned long long)table->lookup_cache_misses,
+                     (unsigned long long)table->attach_failures,
+                     (unsigned long long)table->detach_failures,
+                     (unsigned long long)table->translate_local_failures,
+                     (unsigned long long)table->translate_global_failures,
+                     (unsigned long long)table->inspect_failures,
+                     (unsigned long long)table->cache_invalidations);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }
@@ -2680,6 +2719,8 @@ void aegis_ipc_channel_table_init(aegis_ipc_channel_table_t *table) {
   table->lookup_cache_valid = 0u;
   table->lookup_cache_hits = 0u;
   table->lookup_cache_misses = 0u;
+  table->unknown_channel_requests = 0u;
+  table->drain_underflow_clamps = 0u;
 }
 
 int aegis_ipc_channel_configure(aegis_ipc_channel_table_t *table,
@@ -2730,6 +2771,7 @@ int aegis_ipc_channel_reserve_send(aegis_ipc_channel_table_t *table,
   }
   *accepted_out = 0u;
   if (!ipc_channel_find_index(table, channel_id, &index)) {
+    table->unknown_channel_requests += 1u;
     return -1;
   }
   projected = (uint64_t)table->channels[index].inflight_bytes + (uint64_t)payload_bytes;
@@ -2755,9 +2797,13 @@ int aegis_ipc_channel_drain(aegis_ipc_channel_table_t *table,
     return -1;
   }
   if (!ipc_channel_find_index(table, channel_id, &index)) {
+    table->unknown_channel_requests += 1u;
     return -1;
   }
   if (drained_bytes >= table->channels[index].inflight_bytes) {
+    if (drained_bytes > table->channels[index].inflight_bytes) {
+      table->drain_underflow_clamps += 1u;
+    }
     table->channels[index].inflight_bytes = 0u;
     return 0;
   }
@@ -2780,12 +2826,15 @@ int aegis_ipc_channel_snapshot_json(const aegis_ipc_channel_table_t *table,
                      "{\"schema_version\":1,\"total_accepted_messages\":%llu,"
                      "\"total_dropped_messages\":%llu,\"total_backpressure_events\":%llu,"
                      "\"lookup_cache_hits\":%llu,\"lookup_cache_misses\":%llu,"
+                     "\"unknown_channel_requests\":%llu,\"drain_underflow_clamps\":%llu,"
                      "\"channels\":[",
                      (unsigned long long)table->total_accepted_messages,
                      (unsigned long long)table->total_dropped_messages,
                      (unsigned long long)table->total_backpressure_events,
                      (unsigned long long)table->lookup_cache_hits,
-                     (unsigned long long)table->lookup_cache_misses);
+                     (unsigned long long)table->lookup_cache_misses,
+                     (unsigned long long)table->unknown_channel_requests,
+                     (unsigned long long)table->drain_underflow_clamps);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }
@@ -2864,6 +2913,9 @@ void aegis_memory_zone_table_init(aegis_memory_zone_table_t *table) {
   table->lookup_cache_valid = 0u;
   table->lookup_cache_hits = 0u;
   table->lookup_cache_misses = 0u;
+  table->unknown_zone_requests = 0u;
+  table->release_underflow_clamps = 0u;
+  table->reclaim_shortfall_events = 0u;
   for (i = 0; i < AEGIS_MEMORY_ZONE_CAPACITY; ++i) {
     table->zones[i].zone_id = 0u;
     table->zones[i].zone_kind = 0u;
@@ -2957,6 +3009,7 @@ int aegis_memory_zone_charge(aegis_memory_zone_table_t *table,
   }
   *accepted_out = 0u;
   if (!memory_zone_find_index(table, zone_id, &idx)) {
+    table->unknown_zone_requests += 1u;
     return -1;
   }
   projected = table->zones[idx].used_bytes + bytes;
@@ -2993,6 +3046,7 @@ int aegis_memory_zone_charge(aegis_memory_zone_table_t *table,
       *accepted_out = 1u;
       return 1;
     }
+    table->reclaim_shortfall_events += 1u;
   }
   table->denied_charges += 1u;
   return 0;
@@ -3007,10 +3061,12 @@ int aegis_memory_zone_release(aegis_memory_zone_table_t *table,
     return -1;
   }
   if (!memory_zone_find_index(table, zone_id, &idx)) {
+    table->unknown_zone_requests += 1u;
     return -1;
   }
   drained = bytes;
   if (drained > table->zones[idx].used_bytes) {
+    table->release_underflow_clamps += 1u;
     drained = table->zones[idx].used_bytes;
   }
   table->zones[idx].used_bytes -= drained;
@@ -3036,13 +3092,18 @@ int aegis_memory_zone_snapshot_json(const aegis_memory_zone_table_t *table,
                      out_size,
                      "{\"schema_version\":1,\"total_budget_bytes\":%llu,\"total_used_bytes\":%llu,"
                      "\"denied_charges\":%llu,\"reclaim_events\":%llu,"
-                     "\"lookup_cache_hits\":%llu,\"lookup_cache_misses\":%llu,\"zones\":[",
+                     "\"lookup_cache_hits\":%llu,\"lookup_cache_misses\":%llu,"
+                     "\"unknown_zone_requests\":%llu,\"release_underflow_clamps\":%llu,"
+                     "\"reclaim_shortfall_events\":%llu,\"zones\":[",
                      (unsigned long long)table->total_budget_bytes,
                      (unsigned long long)table->total_used_bytes,
                      (unsigned long long)table->denied_charges,
                      (unsigned long long)table->reclaim_events,
                      (unsigned long long)table->lookup_cache_hits,
-                     (unsigned long long)table->lookup_cache_misses);
+                     (unsigned long long)table->lookup_cache_misses,
+                     (unsigned long long)table->unknown_zone_requests,
+                     (unsigned long long)table->release_underflow_clamps,
+                     (unsigned long long)table->reclaim_shortfall_events);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -725,6 +725,7 @@ static int test_namespace_isolation_simulator(void) {
   uint32_t ns_b = 0u;
   uint32_t local_a = 0u;
   uint32_t local_b = 0u;
+  uint32_t local_tmp = 0u;
   uint32_t global = 0u;
   uint32_t local_roundtrip = 0u;
   uint8_t allowed = 0u;
@@ -768,11 +769,41 @@ static int test_namespace_isolation_simulator(void) {
     fprintf(stderr, "same-process inspect should be allowed\n");
     return 1;
   }
+  if (aegis_namespace_attach_process(&table, 6003u, 9999u, &local_tmp) == 0) {
+    fprintf(stderr, "attach should fail for unknown namespace\n");
+    return 1;
+  }
+  if (aegis_namespace_translate_local_to_global(&table, ns_a, 9999u, &global) == 0) {
+    fprintf(stderr, "local->global should fail for unknown local pid\n");
+    return 1;
+  }
+  if (aegis_namespace_translate_global_to_local(&table, ns_b, 6001u, &local_roundtrip) == 0) {
+    fprintf(stderr, "global->local should fail for cross-namespace pid\n");
+    return 1;
+  }
+  if (aegis_namespace_can_inspect(&table, 9999u, 6002u, &allowed) != 0 || allowed != 0u) {
+    fprintf(stderr, "inspect unknown source should deny with success status\n");
+    return 1;
+  }
+  if (aegis_namespace_detach_process(&table, 9999u) == 0) {
+    fprintf(stderr, "detach should fail for unknown process\n");
+    return 1;
+  }
   if (aegis_namespace_snapshot_json(&table, json, sizeof(json)) <= 0 ||
       strstr(json, "\"namespace_count\":3") == 0 ||
       strstr(json, "\"process_count\":2") == 0 ||
       strstr(json, "\"lookup_cache_hits\":") == 0 ||
       strstr(json, "\"lookup_cache_misses\":") == 0 ||
+      strstr(json, "\"attach_failures\":") == 0 ||
+      strstr(json, "\"detach_failures\":") == 0 ||
+      strstr(json, "\"translate_local_failures\":") == 0 ||
+      strstr(json, "\"translate_global_failures\":") == 0 ||
+      strstr(json, "\"inspect_failures\":") == 0 ||
+      strstr(json, "\"cache_invalidations\":") == 0 ||
+      strstr(json, "\"attach_failures\":0") != 0 ||
+      strstr(json, "\"translate_local_failures\":0") != 0 ||
+      strstr(json, "\"translate_global_failures\":0") != 0 ||
+      strstr(json, "\"inspect_failures\":0") != 0 ||
       strstr(json, "\"process_id\":6001") == 0 ||
       strstr(json, "\"process_id\":6002") == 0) {
     fprintf(stderr, "namespace snapshot missing expected fields: %s\n", json);
@@ -922,15 +953,25 @@ static int test_ipc_channel_quota_and_backpressure(void) {
     fprintf(stderr, "ipc reserve send should fail for unknown channel\n");
     return 1;
   }
+  if (aegis_ipc_channel_drain(&table, 999u, 1u) == 0) {
+    fprintf(stderr, "ipc drain should fail for unknown channel\n");
+    return 1;
+  }
+  if (aegis_ipc_channel_drain(&table, 42u, 500u) != 0) {
+    fprintf(stderr, "ipc drain underflow clamp path should succeed\n");
+    return 1;
+  }
   if (aegis_ipc_channel_snapshot_json(&table, json, sizeof(json)) <= 0 ||
       strstr(json, "\"schema_version\":1") == 0 ||
       strstr(json, "\"total_accepted_messages\":2") == 0 ||
       strstr(json, "\"total_dropped_messages\":1") == 0 ||
       strstr(json, "\"total_backpressure_events\":1") == 0 ||
+      strstr(json, "\"unknown_channel_requests\":2") == 0 ||
+      strstr(json, "\"drain_underflow_clamps\":1") == 0 ||
       strstr(json, "\"lookup_cache_hits\":") == 0 ||
       strstr(json, "\"lookup_cache_misses\":") == 0 ||
       strstr(json, "\"channel_id\":42") == 0 ||
-      strstr(json, "\"inflight_bytes\":150") == 0) {
+      strstr(json, "\"inflight_bytes\":0") == 0) {
     fprintf(stderr, "ipc snapshot mismatch: %s\n", json);
     return 1;
   }
@@ -980,10 +1021,25 @@ static int test_memory_zone_accounting_and_reclaim_hooks(void) {
     fprintf(stderr, "memory zone hot-zone cache path release failed\n");
     return 1;
   }
+  if (aegis_memory_zone_charge(&table, 999u, 10u, &accepted) >= 0) {
+    fprintf(stderr, "memory zone charge should fail for unknown zone\n");
+    return 1;
+  }
+  if (aegis_memory_zone_release(&table, 999u, 10u) == 0) {
+    fprintf(stderr, "memory zone release should fail for unknown zone\n");
+    return 1;
+  }
+  if (aegis_memory_zone_release(&table, 1u, 2000u) != 0) {
+    fprintf(stderr, "memory zone release underflow clamp path failed\n");
+    return 1;
+  }
   if (aegis_memory_zone_snapshot_json(&table, json, sizeof(json)) <= 0 ||
       strstr(json, "\"schema_version\":1") == 0 ||
       strstr(json, "\"denied_charges\":2") == 0 ||
       strstr(json, "\"reclaim_events\":2") == 0 ||
+      strstr(json, "\"unknown_zone_requests\":2") == 0 ||
+      strstr(json, "\"release_underflow_clamps\":1") == 0 ||
+      strstr(json, "\"reclaim_shortfall_events\":1") == 0 ||
       strstr(json, "\"lookup_cache_hits\":") == 0 ||
       strstr(json, "\"lookup_cache_misses\":") == 0 ||
       strstr(json, "\"zone_id\":1") == 0 ||


### PR DESCRIPTION
## Summary
- add namespace attach/detach/translate/inspect failure counters and cache invalidation telemetry
- add IPC unknown-channel and drain-underflow clamp telemetry
- add memory unknown-zone, release-underflow clamp, and reclaim-shortfall telemetry
- extend kernel simulation tests for new failure counters and tiny-buffer snapshot regressions
- refresh root and kernel docs with the new telemetry surfaces

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #208
Closes #209
Closes #210
Closes #211
Closes #212
Closes #213
Closes #214
Closes #215
Closes #216
Closes #217
Closes #218
Closes #219
Closes #220
Closes #221
Closes #222