### PR TITLE
Scheduler dual-entry PID cache + regression suite (#224 #225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This repository contains:
 - Namespace attach/detach/translate/inspect failure counters plus cache-invalidation telemetry in namespace snapshots.
 - IPC unknown-channel request and drain-underflow clamp telemetry in channel snapshots.
 - Memory unknown-zone request, release-underflow clamp, and reclaim-shortfall telemetry in zone snapshots.
+- Scheduler PID lookup upgraded to dual-entry cache (primary + victim) to reduce repeated linear scans.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -36,6 +36,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - includes aggregate wait report (`mean`, `p95`, `max`) for tuning and diagnostics.
   - wait-report percentile path now uses selection-based computation to reduce metrics overhead.
   - includes PID lookup-cache fast path for repeated scheduler control-plane queries.
+  - PID lookup now uses dual-entry (primary + victim) cache with promotion for repeated churned PID access.
   - includes bulk scheduler operation API (`add/remove/reprioritize`) with execution telemetry counters.
   - turbo scheduler now adapts candidate cache reuse budget by queue pressure and switch patterns.
   - turbo scoring now penalizes runaway dispatch dominance to preserve fairness under heavy load.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -94,7 +94,11 @@ typedef struct {
   uint32_t pid_lookup_cache_process_id;
   uint16_t pid_lookup_cache_index;
   uint8_t pid_lookup_cache_valid;
+  uint32_t pid_lookup_cache_victim_process_id;
+  uint16_t pid_lookup_cache_victim_index;
+  uint8_t pid_lookup_cache_victim_valid;
   uint64_t pid_lookup_cache_hits;
+  uint64_t pid_lookup_cache_victim_hits;
   uint64_t pid_lookup_cache_misses;
   uint64_t bulk_apply_calls;
   uint64_t bulk_ops_total;

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -605,6 +605,11 @@ static void scheduler_pid_lookup_cache_seed(aegis_scheduler_t *scheduler,
   if (scheduler == 0 || process_id == 0u || index >= AEGIS_SCHEDULER_CAPACITY) {
     return;
   }
+  if (scheduler->pid_lookup_cache_valid != 0u) {
+    scheduler->pid_lookup_cache_victim_process_id = scheduler->pid_lookup_cache_process_id;
+    scheduler->pid_lookup_cache_victim_index = scheduler->pid_lookup_cache_index;
+    scheduler->pid_lookup_cache_victim_valid = 1u;
+  }
   scheduler->pid_lookup_cache_process_id = process_id;
   scheduler->pid_lookup_cache_index = (uint16_t)index;
   scheduler->pid_lookup_cache_valid = 1u;
@@ -615,6 +620,7 @@ static void scheduler_pid_lookup_cache_invalidate(aegis_scheduler_t *scheduler) 
     return;
   }
   scheduler->pid_lookup_cache_valid = 0u;
+  scheduler->pid_lookup_cache_victim_valid = 0u;
 }
 
 void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
@@ -654,7 +660,11 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->pid_lookup_cache_process_id = 0u;
   scheduler->pid_lookup_cache_index = 0u;
   scheduler->pid_lookup_cache_valid = 0u;
+  scheduler->pid_lookup_cache_victim_process_id = 0u;
+  scheduler->pid_lookup_cache_victim_index = 0u;
+  scheduler->pid_lookup_cache_victim_valid = 0u;
   scheduler->pid_lookup_cache_hits = 0u;
+  scheduler->pid_lookup_cache_victim_hits = 0u;
   scheduler->pid_lookup_cache_misses = 0u;
   scheduler->bulk_apply_calls = 0u;
   scheduler->bulk_ops_total = 0u;
@@ -701,7 +711,11 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->pid_lookup_cache_process_id = 0u;
   scheduler->pid_lookup_cache_index = 0u;
   scheduler->pid_lookup_cache_valid = 0u;
+  scheduler->pid_lookup_cache_victim_process_id = 0u;
+  scheduler->pid_lookup_cache_victim_index = 0u;
+  scheduler->pid_lookup_cache_victim_valid = 0u;
   scheduler->pid_lookup_cache_hits = 0u;
+  scheduler->pid_lookup_cache_victim_hits = 0u;
   scheduler->pid_lookup_cache_misses = 0u;
   scheduler->bulk_apply_calls = 0u;
   scheduler->bulk_ops_total = 0u;
@@ -727,6 +741,16 @@ static int find_index(const aegis_scheduler_t *scheduler, uint32_t process_id, s
       scheduler->process_ids[scheduler->pid_lookup_cache_index] == process_id) {
     *index = scheduler->pid_lookup_cache_index;
     ((aegis_scheduler_t *)scheduler)->pid_lookup_cache_hits += 1u;
+    return 1;
+  }
+  if (scheduler->pid_lookup_cache_victim_valid != 0u &&
+      scheduler->pid_lookup_cache_victim_process_id == process_id &&
+      scheduler->pid_lookup_cache_victim_index < scheduler->count &&
+      scheduler->process_ids[scheduler->pid_lookup_cache_victim_index] == process_id) {
+    *index = scheduler->pid_lookup_cache_victim_index;
+    ((aegis_scheduler_t *)scheduler)->pid_lookup_cache_hits += 1u;
+    ((aegis_scheduler_t *)scheduler)->pid_lookup_cache_victim_hits += 1u;
+    scheduler_pid_lookup_cache_seed((aegis_scheduler_t *)scheduler, process_id, *index);
     return 1;
   }
   ((aegis_scheduler_t *)scheduler)->pid_lookup_cache_misses += 1u;
@@ -818,10 +842,7 @@ int aegis_scheduler_remove(aegis_scheduler_t *scheduler, uint32_t process_id) {
   }
   scheduler->turbo_candidate_cache_valid = 0u;
   scheduler->turbo_candidate_cache_budget = 0u;
-  if (scheduler->pid_lookup_cache_valid != 0u &&
-      scheduler->pid_lookup_cache_process_id == process_id) {
-    scheduler_pid_lookup_cache_invalidate(scheduler);
-  }
+  scheduler_pid_lookup_cache_invalidate(scheduler);
   if (scheduler->current_pid == process_id) {
     scheduler->current_pid = 0;
     scheduler->quantum_remaining = 0;
@@ -835,11 +856,6 @@ int aegis_scheduler_remove(aegis_scheduler_t *scheduler, uint32_t process_id) {
     scheduler->enqueued_tick[i - 1] = scheduler->enqueued_tick[i];
     scheduler->wait_ticks_total[i - 1] = scheduler->wait_ticks_total[i];
     scheduler->last_wait_latency[i - 1] = scheduler->last_wait_latency[i];
-  }
-  if (scheduler->pid_lookup_cache_valid != 0u &&
-      scheduler->pid_lookup_cache_index > idx &&
-      scheduler->pid_lookup_cache_index < scheduler->count) {
-    scheduler->pid_lookup_cache_index = (uint16_t)(scheduler->pid_lookup_cache_index - 1u);
   }
   scheduler->count -= 1;
   if (scheduler->count == 0) {
@@ -1074,7 +1090,9 @@ void aegis_scheduler_reset_metrics(aegis_scheduler_t *scheduler) {
   scheduler->turbo_candidate_cache_hits = 0u;
   scheduler->turbo_candidate_cache_misses = 0u;
   scheduler->pid_lookup_cache_valid = 0u;
+  scheduler->pid_lookup_cache_victim_valid = 0u;
   scheduler->pid_lookup_cache_hits = 0u;
+  scheduler->pid_lookup_cache_victim_hits = 0u;
   scheduler->pid_lookup_cache_misses = 0u;
   scheduler->bulk_apply_calls = 0u;
   scheduler->bulk_ops_total = 0u;
@@ -1646,12 +1664,14 @@ int aegis_scheduler_fairness_snapshot_json(const aegis_scheduler_t *scheduler,
   written = snprintf(out,
                      out_size,
                      "{\"schema_version\":1,\"queue_depth\":%llu,\"total_dispatches\":%llu,"
-                     "\"pid_lookup_cache_hits\":%llu,\"pid_lookup_cache_misses\":%llu,"
+                     "\"pid_lookup_cache_hits\":%llu,\"pid_lookup_cache_victim_hits\":%llu,"
+                     "\"pid_lookup_cache_misses\":%llu,"
                      "\"bulk_apply_calls\":%llu,\"bulk_ops_total\":%llu,"
                      "\"bulk_ops_succeeded\":%llu,\"bulk_ops_failed\":%llu,\"processes\":[",
                      (unsigned long long)scheduler->count,
                      (unsigned long long)scheduler->total_dispatches,
                      (unsigned long long)scheduler->pid_lookup_cache_hits,
+                     (unsigned long long)scheduler->pid_lookup_cache_victim_hits,
                      (unsigned long long)scheduler->pid_lookup_cache_misses,
                      (unsigned long long)scheduler->bulk_apply_calls,
                      (unsigned long long)scheduler->bulk_ops_total,
@@ -1755,7 +1775,8 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      out_size,
                      "{\"schema_version\":1,\"profile_id\":%u,\"queue_depth\":%llu,"
                      "\"priority_present_bitmap\":%u,\"runnable_priority_bitmap\":%u,"
-                     "\"pid_lookup_cache_hits\":%llu,\"pid_lookup_cache_misses\":%llu,"
+                     "\"pid_lookup_cache_hits\":%llu,\"pid_lookup_cache_victim_hits\":%llu,"
+                     "\"pid_lookup_cache_misses\":%llu,"
                      "\"bulk_apply_calls\":%llu,\"bulk_ops_total\":%llu,"
                      "\"bulk_ops_succeeded\":%llu,\"bulk_ops_failed\":%llu,"
                      "\"bulk_ops_unknown\":%llu,\"bulk_results_dropped\":%llu,"
@@ -1769,6 +1790,7 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      (unsigned int)scheduler->priority_present_bitmap,
                      (unsigned int)scheduler->runnable_priority_bitmap,
                      (unsigned long long)scheduler->pid_lookup_cache_hits,
+                     (unsigned long long)scheduler->pid_lookup_cache_victim_hits,
                      (unsigned long long)scheduler->pid_lookup_cache_misses,
                      (unsigned long long)scheduler->bulk_apply_calls,
                      (unsigned long long)scheduler->bulk_ops_total,

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -463,6 +463,7 @@ static int test_scheduler_admission_limits_and_snapshot(void) {
   }
   if (strstr(json, "\"schema_version\":1") == 0 ||
       strstr(json, "\"pid_lookup_cache_hits\":") == 0 ||
+      strstr(json, "\"pid_lookup_cache_victim_hits\":") == 0 ||
       strstr(json, "\"pid_lookup_cache_misses\":") == 0 ||
       strstr(json, "\"bulk_apply_calls\":") == 0 ||
       strstr(json, "\"bulk_ops_total\":") == 0 ||
@@ -476,6 +477,49 @@ static int test_scheduler_admission_limits_and_snapshot(void) {
       strstr(json, "\"counts\":{\"high\":1,\"normal\":2,\"low\":0}") == 0 ||
       strstr(json, "\"drops\":{\"high\":1,\"normal\":1,\"low\":0}") == 0) {
     fprintf(stderr, "admission snapshot json missing expected fields: %s\n", json);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_scheduler_dual_entry_pid_lookup_cache(void) {
+  aegis_scheduler_t scheduler;
+  uint32_t dispatch_count = 0u;
+  char json[512];
+  aegis_scheduler_init(&scheduler);
+  if (aegis_scheduler_add_with_priority(&scheduler, 8101u, AEGIS_PRIORITY_NORMAL) != 0 ||
+      aegis_scheduler_add_with_priority(&scheduler, 8102u, AEGIS_PRIORITY_NORMAL) != 0 ||
+      aegis_scheduler_add_with_priority(&scheduler, 8103u, AEGIS_PRIORITY_NORMAL) != 0) {
+    fprintf(stderr, "dual-entry pid cache setup failed\n");
+    return 1;
+  }
+  if (aegis_scheduler_dispatch_count_for(&scheduler, 8101u, &dispatch_count) != 0 ||
+      aegis_scheduler_dispatch_count_for(&scheduler, 8102u, &dispatch_count) != 0 ||
+      aegis_scheduler_dispatch_count_for(&scheduler, 8101u, &dispatch_count) != 0) {
+    fprintf(stderr, "dual-entry pid cache lookup sequence failed\n");
+    return 1;
+  }
+  if (scheduler.pid_lookup_cache_hits == 0u ||
+      scheduler.pid_lookup_cache_victim_hits == 0u ||
+      scheduler.pid_lookup_cache_misses == 0u) {
+    fprintf(stderr, "dual-entry pid cache counters mismatch\n");
+    return 1;
+  }
+  if (aegis_scheduler_admission_snapshot_json(&scheduler, json, sizeof(json)) <= 0 ||
+      strstr(json, "\"pid_lookup_cache_victim_hits\":") == 0) {
+    fprintf(stderr, "dual-entry pid cache snapshot field missing: %s\n", json);
+    return 1;
+  }
+  if (aegis_scheduler_remove(&scheduler, 8102u) != 0) {
+    fprintf(stderr, "dual-entry pid cache remove failed\n");
+    return 1;
+  }
+  if (aegis_scheduler_dispatch_count_for(&scheduler, 8101u, &dispatch_count) != 0) {
+    fprintf(stderr, "dual-entry pid cache lookup after remove failed\n");
+    return 1;
+  }
+  if (scheduler.pid_lookup_cache_misses < 2u) {
+    fprintf(stderr, "dual-entry pid cache should miss after remove invalidation\n");
     return 1;
   }
   return 0;
@@ -1638,6 +1682,7 @@ static int test_scheduler_fairness_snapshot_json_endpoint(void) {
   if (strstr(json, "\"schema_version\":1") == 0 ||
       strstr(json, "\"queue_depth\":3") == 0 ||
       strstr(json, "\"pid_lookup_cache_hits\":") == 0 ||
+      strstr(json, "\"pid_lookup_cache_victim_hits\":") == 0 ||
       strstr(json, "\"bulk_apply_calls\":") == 0 ||
       strstr(json, "\"process_id\":9801") == 0 ||
       strstr(json, "\"dispatch_share_bps\":") == 0 ||
@@ -1966,6 +2011,9 @@ int main(void) {
     return 1;
   }
   if (test_scheduler_admission_limits_and_snapshot() != 0) {
+    return 1;
+  }
+  if (test_scheduler_dual_entry_pid_lookup_cache() != 0) {
     return 1;
   }
   if (test_scheduler_admission_profile_presets() != 0) {


### PR DESCRIPTION
## Summary
- upgrade scheduler PID lookup cache from single-entry to dual-entry (primary + victim)
- promote victim entry on hit to reduce repeated linear PID scans under churn
- invalidate dual-entry PID cache on remove to keep index shifts safe
- expose pid_lookup_cache_victim_hits in scheduler snapshot JSON surfaces
- add regression test covering victim-hit path and remove-invalidation behavior
- refresh docs for the new scheduler lookup strategy

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #224
Closes #225