### PR TITLE
Scheduler dispatch scan-depth telemetry (#227)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This repository contains:
 - IPC unknown-channel request and drain-underflow clamp telemetry in channel snapshots.
 - Memory unknown-zone request, release-underflow clamp, and reclaim-shortfall telemetry in zone snapshots.
 - Scheduler PID lookup upgraded to dual-entry cache (primary + victim) to reduce repeated linear scans.
+- Scheduler dispatch scan-depth telemetry to quantify round-robin/turbo hot-path scan cost.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -22,6 +22,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - turbo mode includes adaptive weight autotuning to rebalance `priority` vs `wait` based on live latency telemetry.
   - low-priority aging boosts add temporary credits after long waits to reduce starvation risk.
   - includes dispatch metrics: total dispatches, high-watermark queue depth, and per-process counts.
+  - tracks dispatch scan-depth telemetry (`calls`, `steps_total`, `max_steps`) for hot-path tuning.
   - includes timer-tick preemption simulation hooks with configurable quantum.
   - context switches expose reason codes (`process_start`, `quantum_expired`, `process_exit`, `manual_yield`).
   - includes per-reason context-switch counters for metrics breakdowns and alerting.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -108,6 +108,9 @@ typedef struct {
   uint64_t bulk_results_dropped;
   uint64_t turbo_reuse_budget_adaptations;
   uint64_t wait_latency_clamp_events;
+  uint64_t dispatch_scan_calls;
+  uint64_t dispatch_scan_steps_total;
+  uint64_t dispatch_scan_max_steps;
   uint32_t turbo_last_pid;
   size_t count;
   size_t head;

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -599,6 +599,17 @@ static uint64_t scheduler_total_switches(const aegis_scheduler_t *scheduler) {
          scheduler->reason_switch_counts[AEGIS_SWITCH_MANUAL_YIELD];
 }
 
+static void scheduler_record_dispatch_scan(aegis_scheduler_t *scheduler, size_t steps) {
+  if (scheduler == 0) {
+    return;
+  }
+  scheduler->dispatch_scan_calls += 1u;
+  scheduler->dispatch_scan_steps_total += (uint64_t)steps;
+  if ((uint64_t)steps > scheduler->dispatch_scan_max_steps) {
+    scheduler->dispatch_scan_max_steps = (uint64_t)steps;
+  }
+}
+
 static void scheduler_pid_lookup_cache_seed(aegis_scheduler_t *scheduler,
                                             uint32_t process_id,
                                             size_t index) {
@@ -674,6 +685,9 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->bulk_results_dropped = 0u;
   scheduler->turbo_reuse_budget_adaptations = 0u;
   scheduler->wait_latency_clamp_events = 0u;
+  scheduler->dispatch_scan_calls = 0u;
+  scheduler->dispatch_scan_steps_total = 0u;
+  scheduler->dispatch_scan_max_steps = 0u;
   scheduler->turbo_last_pid = 0u;
   scheduler->admission_profile_id = AEGIS_SCHED_ADMISSION_PROFILE_CUSTOM;
   scheduler->runnable_credit_count = 0u;
@@ -725,6 +739,9 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->bulk_results_dropped = 0u;
   scheduler->turbo_reuse_budget_adaptations = 0u;
   scheduler->wait_latency_clamp_events = 0u;
+  scheduler->dispatch_scan_calls = 0u;
+  scheduler->dispatch_scan_steps_total = 0u;
+  scheduler->dispatch_scan_max_steps = 0u;
   scheduler->quantum_autotune_last_tick = 0u;
   scheduler->quantum_autotune_last_switch_total = 0u;
   scheduler->quantum_autotune_adjustments = 0u;
@@ -959,6 +976,7 @@ int aegis_scheduler_apply_batch(aegis_scheduler_t *scheduler,
 int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
   size_t attempts;
   size_t chosen_idx = 0u;
+  size_t scan_steps = 0u;
   if (scheduler == 0 || process_id == 0 || scheduler->count == 0) {
     return -1;
   }
@@ -968,6 +986,8 @@ int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
   if (scheduler->dispatch_strategy == AEGIS_SCHED_STRATEGY_TURBO &&
       scheduler_pick_turbo_index(scheduler, &chosen_idx)) {
     uint64_t wait_delta = 0u;
+    scan_steps = 1u;
+    scheduler_record_dispatch_scan(scheduler, scan_steps);
     scheduler->credits[chosen_idx] -= 1;
     if (scheduler->credits[chosen_idx] == 0u) {
       scheduler_runnable_credit_dec(scheduler, scheduler->priorities[chosen_idx]);
@@ -991,9 +1011,11 @@ int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
   for (attempts = 0; attempts < scheduler->count; ++attempts) {
     size_t idx = (scheduler->head + attempts) % scheduler->count;
     uint64_t wait_delta = 0u;
+    scan_steps += 1u;
     if (scheduler->credits[idx] == 0) {
       continue;
     }
+    scheduler_record_dispatch_scan(scheduler, scan_steps);
     scheduler->credits[idx] -= 1;
     if (scheduler->credits[idx] == 0u) {
       scheduler_runnable_credit_dec(scheduler, scheduler->priorities[idx]);
@@ -1014,6 +1036,7 @@ int aegis_scheduler_next(aegis_scheduler_t *scheduler, uint32_t *process_id) {
     scheduler->turbo_last_pid = *process_id;
     return 0;
   }
+  scheduler_record_dispatch_scan(scheduler, scan_steps);
   return -1;
 }
 
@@ -1102,6 +1125,9 @@ void aegis_scheduler_reset_metrics(aegis_scheduler_t *scheduler) {
   scheduler->bulk_results_dropped = 0u;
   scheduler->turbo_reuse_budget_adaptations = 0u;
   scheduler->wait_latency_clamp_events = 0u;
+  scheduler->dispatch_scan_calls = 0u;
+  scheduler->dispatch_scan_steps_total = 0u;
+  scheduler->dispatch_scan_max_steps = 0u;
   scheduler->quantum_autotune_last_tick = scheduler->scheduler_ticks;
   scheduler->quantum_autotune_last_switch_total = 0u;
   scheduler->quantum_autotune_adjustments = 0u;
@@ -1666,6 +1692,8 @@ int aegis_scheduler_fairness_snapshot_json(const aegis_scheduler_t *scheduler,
                      "{\"schema_version\":1,\"queue_depth\":%llu,\"total_dispatches\":%llu,"
                      "\"pid_lookup_cache_hits\":%llu,\"pid_lookup_cache_victim_hits\":%llu,"
                      "\"pid_lookup_cache_misses\":%llu,"
+                     "\"dispatch_scan_calls\":%llu,\"dispatch_scan_steps_total\":%llu,"
+                     "\"dispatch_scan_max_steps\":%llu,"
                      "\"bulk_apply_calls\":%llu,\"bulk_ops_total\":%llu,"
                      "\"bulk_ops_succeeded\":%llu,\"bulk_ops_failed\":%llu,\"processes\":[",
                      (unsigned long long)scheduler->count,
@@ -1673,6 +1701,9 @@ int aegis_scheduler_fairness_snapshot_json(const aegis_scheduler_t *scheduler,
                      (unsigned long long)scheduler->pid_lookup_cache_hits,
                      (unsigned long long)scheduler->pid_lookup_cache_victim_hits,
                      (unsigned long long)scheduler->pid_lookup_cache_misses,
+                     (unsigned long long)scheduler->dispatch_scan_calls,
+                     (unsigned long long)scheduler->dispatch_scan_steps_total,
+                     (unsigned long long)scheduler->dispatch_scan_max_steps,
                      (unsigned long long)scheduler->bulk_apply_calls,
                      (unsigned long long)scheduler->bulk_ops_total,
                      (unsigned long long)scheduler->bulk_ops_succeeded,
@@ -1777,6 +1808,8 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      "\"priority_present_bitmap\":%u,\"runnable_priority_bitmap\":%u,"
                      "\"pid_lookup_cache_hits\":%llu,\"pid_lookup_cache_victim_hits\":%llu,"
                      "\"pid_lookup_cache_misses\":%llu,"
+                     "\"dispatch_scan_calls\":%llu,\"dispatch_scan_steps_total\":%llu,"
+                     "\"dispatch_scan_max_steps\":%llu,"
                      "\"bulk_apply_calls\":%llu,\"bulk_ops_total\":%llu,"
                      "\"bulk_ops_succeeded\":%llu,\"bulk_ops_failed\":%llu,"
                      "\"bulk_ops_unknown\":%llu,\"bulk_results_dropped\":%llu,"
@@ -1792,6 +1825,9 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      (unsigned long long)scheduler->pid_lookup_cache_hits,
                      (unsigned long long)scheduler->pid_lookup_cache_victim_hits,
                      (unsigned long long)scheduler->pid_lookup_cache_misses,
+                     (unsigned long long)scheduler->dispatch_scan_calls,
+                     (unsigned long long)scheduler->dispatch_scan_steps_total,
+                     (unsigned long long)scheduler->dispatch_scan_max_steps,
                      (unsigned long long)scheduler->bulk_apply_calls,
                      (unsigned long long)scheduler->bulk_ops_total,
                      (unsigned long long)scheduler->bulk_ops_succeeded,

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -217,6 +217,12 @@ static int test_scheduler_round_robin(void) {
     fprintf(stderr, "expected pid 1001 after wrap\n");
     return 1;
   }
+  if (scheduler.dispatch_scan_calls == 0u ||
+      scheduler.dispatch_scan_steps_total < scheduler.dispatch_scan_calls ||
+      scheduler.dispatch_scan_max_steps == 0u) {
+    fprintf(stderr, "dispatch scan telemetry expected non-zero activity\n");
+    return 1;
+  }
   return 0;
 }
 
@@ -413,7 +419,7 @@ static int test_scheduler_admission_limits_and_snapshot(void) {
   uint8_t limit = 0u;
   uint64_t drops = 0u;
   uint32_t dispatch_count = 0u;
-  char json[512];
+  char json[1024];
   aegis_scheduler_init(&scheduler);
   if (aegis_scheduler_set_admission_limit(&scheduler, AEGIS_PRIORITY_HIGH, 1u) != 0 ||
       aegis_scheduler_set_admission_limit(&scheduler, AEGIS_PRIORITY_NORMAL, 2u) != 0 ||
@@ -465,6 +471,9 @@ static int test_scheduler_admission_limits_and_snapshot(void) {
       strstr(json, "\"pid_lookup_cache_hits\":") == 0 ||
       strstr(json, "\"pid_lookup_cache_victim_hits\":") == 0 ||
       strstr(json, "\"pid_lookup_cache_misses\":") == 0 ||
+      strstr(json, "\"dispatch_scan_calls\":") == 0 ||
+      strstr(json, "\"dispatch_scan_steps_total\":") == 0 ||
+      strstr(json, "\"dispatch_scan_max_steps\":") == 0 ||
       strstr(json, "\"bulk_apply_calls\":") == 0 ||
       strstr(json, "\"bulk_ops_total\":") == 0 ||
       strstr(json, "\"bulk_ops_succeeded\":") == 0 ||
@@ -485,7 +494,7 @@ static int test_scheduler_admission_limits_and_snapshot(void) {
 static int test_scheduler_dual_entry_pid_lookup_cache(void) {
   aegis_scheduler_t scheduler;
   uint32_t dispatch_count = 0u;
-  char json[512];
+  char json[1024];
   aegis_scheduler_init(&scheduler);
   if (aegis_scheduler_add_with_priority(&scheduler, 8101u, AEGIS_PRIORITY_NORMAL) != 0 ||
       aegis_scheduler_add_with_priority(&scheduler, 8102u, AEGIS_PRIORITY_NORMAL) != 0 ||
@@ -528,7 +537,7 @@ static int test_scheduler_dual_entry_pid_lookup_cache(void) {
 static int test_scheduler_admission_profile_presets(void) {
   aegis_scheduler_t scheduler;
   uint8_t profile = 0u;
-  char json[512];
+  char json[1024];
   aegis_scheduler_init(&scheduler);
   if (aegis_scheduler_apply_admission_profile(&scheduler, AEGIS_SCHED_ADMISSION_PROFILE_MINIMAL) != 0) {
     fprintf(stderr, "failed to apply minimal admission profile\n");
@@ -586,7 +595,7 @@ static int test_scheduler_bulk_apply_api_and_metrics(void) {
   aegis_scheduler_t scheduler;
   aegis_scheduler_bulk_op_t ops[6];
   aegis_scheduler_bulk_result_t results[3];
-  char json[512];
+  char json[1024];
   size_t applied = 0u;
   memset(ops, 0, sizeof(ops));
   memset(results, 0, sizeof(results));
@@ -706,7 +715,7 @@ static int test_scheduler_bulk_apply_rejection_paths(void) {
 
 static int test_scheduler_priority_count_tracking_after_reprioritize(void) {
   aegis_scheduler_t scheduler;
-  char json[512];
+  char json[1024];
   aegis_scheduler_init(&scheduler);
   if (aegis_scheduler_add_with_priority(&scheduler, 9701u, AEGIS_PRIORITY_HIGH) != 0 ||
       aegis_scheduler_add_with_priority(&scheduler, 9702u, AEGIS_PRIORITY_NORMAL) != 0 ||
@@ -1488,7 +1497,7 @@ static int test_scheduler_reason_histogram_custom_window_query_json(void) {
   aegis_scheduler_t scheduler;
   uint32_t pid = 0;
   uint8_t switched = 0;
-  char json[512];
+  char json[1024];
   int i;
   aegis_scheduler_init(&scheduler);
   aegis_scheduler_set_quantum(&scheduler, 1u);
@@ -1683,6 +1692,9 @@ static int test_scheduler_fairness_snapshot_json_endpoint(void) {
       strstr(json, "\"queue_depth\":3") == 0 ||
       strstr(json, "\"pid_lookup_cache_hits\":") == 0 ||
       strstr(json, "\"pid_lookup_cache_victim_hits\":") == 0 ||
+      strstr(json, "\"dispatch_scan_calls\":") == 0 ||
+      strstr(json, "\"dispatch_scan_steps_total\":") == 0 ||
+      strstr(json, "\"dispatch_scan_max_steps\":") == 0 ||
       strstr(json, "\"bulk_apply_calls\":") == 0 ||
       strstr(json, "\"process_id\":9801") == 0 ||
       strstr(json, "\"dispatch_share_bps\":") == 0 ||


### PR DESCRIPTION
## Summary
- add scheduler dispatch scan-depth telemetry counters (dispatch_scan_calls, dispatch_scan_steps_total, dispatch_scan_max_steps)
- record scan depth across turbo and round-robin dispatch paths
- include scan telemetry in fairness and admission snapshot JSON payloads
- extend scheduler tests to validate new telemetry fields and activity
- refresh root/kernel docs with scan-depth observability notes

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #227