### PR TITLE
IPC drop-reason breakdown counters in snapshot telemetry (#232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This repository contains:
 - Namespace translation lookup-cache and scheduler percentile-selection fast path for lower runtime metrics overhead.
 - Namespace attach/detach/translate/inspect failure counters plus cache-invalidation telemetry in namespace snapshots.
 - IPC unknown-channel request and drain-underflow clamp telemetry in channel snapshots.
+- IPC drop-reason breakdown counters (`quota`, `unknown_channel`, `policy_gate`) in channel snapshots.
 - Memory unknown-zone request, release-underflow clamp, and reclaim-shortfall telemetry in zone snapshots.
 - Scheduler PID lookup upgraded to dual-entry cache (primary + victim) to reduce repeated linear scans.
 - Scheduler dispatch scan-depth telemetry to quantify round-robin/turbo hot-path scan cost.

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -62,6 +62,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - include lookup-cache fast paths for hot channel/zone IDs.
   - expose lookup-cache hit/miss telemetry in JSON snapshots.
   - include IPC unknown-channel and drain-underflow clamp counters in snapshot telemetry.
+  - include IPC drop-reason breakdown counters (`quota`, `unknown_channel`, `policy_gate`) for triage.
   - include memory unknown-zone, release-underflow clamp, and reclaim-shortfall counters.
 - `aegis_namespace_table_t`:
   - includes lookup-cache fast paths for local/global pid translation.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -276,6 +276,9 @@ typedef struct {
   uint64_t lookup_cache_misses;
   uint64_t unknown_channel_requests;
   uint64_t drain_underflow_clamps;
+  uint64_t drop_reason_quota;
+  uint64_t drop_reason_unknown_channel;
+  uint64_t drop_reason_policy_gate;
 } aegis_ipc_channel_table_t;
 
 typedef enum {

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -2779,6 +2779,9 @@ void aegis_ipc_channel_table_init(aegis_ipc_channel_table_t *table) {
   table->lookup_cache_misses = 0u;
   table->unknown_channel_requests = 0u;
   table->drain_underflow_clamps = 0u;
+  table->drop_reason_quota = 0u;
+  table->drop_reason_unknown_channel = 0u;
+  table->drop_reason_policy_gate = 0u;
 }
 
 int aegis_ipc_channel_configure(aegis_ipc_channel_table_t *table,
@@ -2830,6 +2833,7 @@ int aegis_ipc_channel_reserve_send(aegis_ipc_channel_table_t *table,
   *accepted_out = 0u;
   if (!ipc_channel_find_index(table, channel_id, &index)) {
     table->unknown_channel_requests += 1u;
+    table->drop_reason_unknown_channel += 1u;
     return -1;
   }
   projected = (uint64_t)table->channels[index].inflight_bytes + (uint64_t)payload_bytes;
@@ -2838,6 +2842,7 @@ int aegis_ipc_channel_reserve_send(aegis_ipc_channel_table_t *table,
     table->channels[index].backpressure_events += 1u;
     table->total_dropped_messages += 1u;
     table->total_backpressure_events += 1u;
+    table->drop_reason_quota += 1u;
     return 0;
   }
   table->channels[index].inflight_bytes = (uint32_t)projected;
@@ -2885,6 +2890,8 @@ int aegis_ipc_channel_snapshot_json(const aegis_ipc_channel_table_t *table,
                      "\"total_dropped_messages\":%llu,\"total_backpressure_events\":%llu,"
                      "\"lookup_cache_hits\":%llu,\"lookup_cache_misses\":%llu,"
                      "\"unknown_channel_requests\":%llu,\"drain_underflow_clamps\":%llu,"
+                     "\"drop_reason_quota\":%llu,\"drop_reason_unknown_channel\":%llu,"
+                     "\"drop_reason_policy_gate\":%llu,"
                      "\"channels\":[",
                      (unsigned long long)table->total_accepted_messages,
                      (unsigned long long)table->total_dropped_messages,
@@ -2892,7 +2899,10 @@ int aegis_ipc_channel_snapshot_json(const aegis_ipc_channel_table_t *table,
                      (unsigned long long)table->lookup_cache_hits,
                      (unsigned long long)table->lookup_cache_misses,
                      (unsigned long long)table->unknown_channel_requests,
-                     (unsigned long long)table->drain_underflow_clamps);
+                     (unsigned long long)table->drain_underflow_clamps,
+                     (unsigned long long)table->drop_reason_quota,
+                     (unsigned long long)table->drop_reason_unknown_channel,
+                     (unsigned long long)table->drop_reason_policy_gate);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -1021,6 +1021,9 @@ static int test_ipc_channel_quota_and_backpressure(void) {
       strstr(json, "\"total_backpressure_events\":1") == 0 ||
       strstr(json, "\"unknown_channel_requests\":2") == 0 ||
       strstr(json, "\"drain_underflow_clamps\":1") == 0 ||
+      strstr(json, "\"drop_reason_quota\":1") == 0 ||
+      strstr(json, "\"drop_reason_unknown_channel\":1") == 0 ||
+      strstr(json, "\"drop_reason_policy_gate\":0") == 0 ||
       strstr(json, "\"lookup_cache_hits\":") == 0 ||
       strstr(json, "\"lookup_cache_misses\":") == 0 ||
       strstr(json, "\"channel_id\":42") == 0 ||


### PR DESCRIPTION
## Summary
- add IPC table-level drop-reason counters for quota, unknown_channel, and policy_gate
- increment unknown-channel reason counter when reserve-send targets missing channel
- increment quota reason counter on backpressure quota drops
- expose new reason counters in IPC snapshot JSON
- extend IPC regression test assertions for new fields and expected counts
- refresh docs with drop-reason telemetry coverage

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #232