### PR TITLE
Namespace inspect-pair cache fastpath (#229)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This repository contains:
 - Scheduler PID lookup upgraded to dual-entry cache (primary + victim) to reduce repeated linear scans.
 - Scheduler dispatch scan-depth telemetry to quantify round-robin/turbo hot-path scan cost.
 - Scheduler ready-bitmap popcount fastpath for single-class runnable dispatch cycles.
+- Namespace requester/target inspect-pair cache fastpath with hit/miss telemetry.
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -67,6 +67,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - include memory unknown-zone, release-underflow clamp, and reclaim-shortfall counters.
 - `aegis_namespace_table_t`:
   - includes lookup-cache fast paths for local/global pid translation.
+  - includes requester/target inspect-pair cache fastpath for repeated visibility checks.
   - exposes lookup-cache hit/miss telemetry in namespace snapshot JSON.
   - tracks attach/detach/translate/inspect failure counters for error-path observability.
   - tracks namespace cache invalidation count to expose mutation churn.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -441,6 +441,12 @@ typedef struct {
   uint64_t translate_global_failures;
   uint64_t inspect_failures;
   uint64_t cache_invalidations;
+  uint32_t inspect_cache_requester_process_id;
+  uint32_t inspect_cache_target_process_id;
+  uint8_t inspect_cache_allowed;
+  uint8_t inspect_cache_valid;
+  uint64_t inspect_cache_hits;
+  uint64_t inspect_cache_misses;
 } aegis_namespace_table_t;
 
 int aegis_kernel_boot_check(void);

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -2098,6 +2098,12 @@ void aegis_namespace_table_init(aegis_namespace_table_t *table) {
   table->translate_global_failures = 0u;
   table->inspect_failures = 0u;
   table->cache_invalidations = 0u;
+  table->inspect_cache_requester_process_id = 0u;
+  table->inspect_cache_target_process_id = 0u;
+  table->inspect_cache_allowed = 0u;
+  table->inspect_cache_valid = 0u;
+  table->inspect_cache_hits = 0u;
+  table->inspect_cache_misses = 0u;
   for (i = 0; i < AEGIS_NAMESPACE_CAPACITY; ++i) {
     table->namespaces[i].namespace_id = 0u;
     table->namespaces[i].parent_namespace_id = 0u;
@@ -2145,6 +2151,7 @@ int aegis_namespace_create(aegis_namespace_table_t *table,
     table->next_namespace_id += 1u;
     table->namespace_count += 1u;
     table->lookup_cache_valid = 0u;
+    table->inspect_cache_valid = 0u;
     table->cache_invalidations += 1u;
     return 0;
   }
@@ -2188,6 +2195,7 @@ int aegis_namespace_destroy(aegis_namespace_table_t *table, uint32_t namespace_i
     table->namespace_count -= 1u;
   }
   table->lookup_cache_valid = 0u;
+  table->inspect_cache_valid = 0u;
   table->cache_invalidations += 1u;
   return 0;
 }
@@ -2232,6 +2240,7 @@ int aegis_namespace_attach_process(aegis_namespace_table_t *table,
     table->lookup_cache_process_id = process_id;
     table->lookup_cache_local_pid = local_pid;
     table->lookup_cache_index = (uint16_t)i;
+    table->inspect_cache_valid = 0u;
     return 0;
   }
   table->attach_failures += 1u;
@@ -2266,6 +2275,7 @@ int aegis_namespace_detach_process(aegis_namespace_table_t *table, uint32_t proc
     table->process_count -= 1u;
   }
   table->lookup_cache_valid = 0u;
+  table->inspect_cache_valid = 0u;
   table->cache_invalidations += 1u;
   return 0;
 }
@@ -2313,6 +2323,14 @@ int aegis_namespace_can_inspect(const aegis_namespace_table_t *table,
     return -1;
   }
   *allowed_out = 0u;
+  if (table->inspect_cache_valid != 0u &&
+      table->inspect_cache_requester_process_id == requester_process_id &&
+      table->inspect_cache_target_process_id == target_process_id) {
+    *allowed_out = table->inspect_cache_allowed;
+    ((aegis_namespace_table_t *)table)->inspect_cache_hits += 1u;
+    return 0;
+  }
+  ((aegis_namespace_table_t *)table)->inspect_cache_misses += 1u;
   if (!namespace_process_find_by_global(table, requester_process_id, &req_index) ||
       !namespace_process_find_by_global(table, target_process_id, &tgt_index)) {
     ((aegis_namespace_table_t *)table)->inspect_failures += 1u;
@@ -2321,6 +2339,10 @@ int aegis_namespace_can_inspect(const aegis_namespace_table_t *table,
   if (table->processes[req_index].namespace_id == table->processes[tgt_index].namespace_id) {
     *allowed_out = 1u;
   }
+  ((aegis_namespace_table_t *)table)->inspect_cache_requester_process_id = requester_process_id;
+  ((aegis_namespace_table_t *)table)->inspect_cache_target_process_id = target_process_id;
+  ((aegis_namespace_table_t *)table)->inspect_cache_allowed = *allowed_out;
+  ((aegis_namespace_table_t *)table)->inspect_cache_valid = 1u;
   return 0;
 }
 
@@ -2342,6 +2364,7 @@ int aegis_namespace_snapshot_json(const aegis_namespace_table_t *table,
                      "\"attach_failures\":%llu,\"detach_failures\":%llu,"
                      "\"translate_local_failures\":%llu,\"translate_global_failures\":%llu,"
                      "\"inspect_failures\":%llu,\"cache_invalidations\":%llu,"
+                     "\"inspect_cache_hits\":%llu,\"inspect_cache_misses\":%llu,"
                      "\"namespaces\":[",
                      (unsigned long long)table->namespace_count,
                      (unsigned long long)table->process_count,
@@ -2352,7 +2375,9 @@ int aegis_namespace_snapshot_json(const aegis_namespace_table_t *table,
                      (unsigned long long)table->translate_local_failures,
                      (unsigned long long)table->translate_global_failures,
                      (unsigned long long)table->inspect_failures,
-                     (unsigned long long)table->cache_invalidations);
+                     (unsigned long long)table->cache_invalidations,
+                     (unsigned long long)table->inspect_cache_hits,
+                     (unsigned long long)table->inspect_cache_misses);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
   }

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -829,6 +829,10 @@ static int test_namespace_isolation_simulator(void) {
     fprintf(stderr, "same-process inspect should be allowed\n");
     return 1;
   }
+  if (aegis_namespace_can_inspect(&table, 6001u, 6001u, &allowed) != 0 || allowed != 1u) {
+    fprintf(stderr, "same-process inspect cache-hit should be allowed\n");
+    return 1;
+  }
   if (aegis_namespace_attach_process(&table, 6003u, 9999u, &local_tmp) == 0) {
     fprintf(stderr, "attach should fail for unknown namespace\n");
     return 1;
@@ -860,6 +864,9 @@ static int test_namespace_isolation_simulator(void) {
       strstr(json, "\"translate_global_failures\":") == 0 ||
       strstr(json, "\"inspect_failures\":") == 0 ||
       strstr(json, "\"cache_invalidations\":") == 0 ||
+      strstr(json, "\"inspect_cache_hits\":") == 0 ||
+      strstr(json, "\"inspect_cache_misses\":") == 0 ||
+      strstr(json, "\"inspect_cache_hits\":0") != 0 ||
       strstr(json, "\"attach_failures\":0") != 0 ||
       strstr(json, "\"translate_local_failures\":0") != 0 ||
       strstr(json, "\"translate_global_failures\":0") != 0 ||


### PR DESCRIPTION
## Summary
- add namespace inspect requester/target pair cache for repeated visibility checks
- add inspect-pair cache hit/miss counters to namespace snapshot telemetry
- invalidate inspect cache on namespace/process mutation paths
- keep failure accounting semantics unchanged while reducing hot inspect lookup cost
- extend namespace tests to verify inspect cache hits and snapshot fields
- refresh docs with inspect-pair fastpath coverage

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #229