### PR TITLE
Kernel hotpath benchmark CLI + perf budget CI gate (#237 #238)

### DIFF
--- a/.github/workflows/perf-budget.yml
+++ b/.github/workflows/perf-budget.yml
@@ -1,0 +1,35 @@
+name: Kernel Perf Budget
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "EXPLAIN.md"
+      - "CHANGELOG.md"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "EXPLAIN.md"
+      - "CHANGELOG.md"
+
+jobs:
+  kernel-perf-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run kernel perf budget gate
+        run: python scripts/kernel_perf_budget_gate.py --emit-benchmark-json out_kernel_hotpath_bench.json
+
+      - name: Upload benchmark artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-hotpath-benchmark-json
+          path: out_kernel_hotpath_bench.json

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ This repository contains:
   - includes ASAN/UBSAN sanitizer jobs for memory and undefined behavior checks.
   - sanitizer suppression baseline and policy docs: [`docs/SANITIZERS.md`](docs/SANITIZERS.md).
   - includes trace JSON property smoke profiling for regression triage: [`docs/TRACE_JSON_PROPERTY.md`](docs/TRACE_JSON_PROPERTY.md).
+- [`Kernel Perf Budget workflow`](.github/workflows/perf-budget.yml) runs cross-module hotpath benchmark and fails CI on budget regressions.
+  - budget profile: [`docs/PERF_BUDGET.json`](docs/PERF_BUDGET.json).
+  - local benchmark CLI: `python scripts/kernel_hotpath_benchmark.py --iterations 200000`.
+  - local gate run: `python scripts/kernel_perf_budget_gate.py`.
 
 ## Collaboration
 

--- a/docs/PERF_BUDGET.json
+++ b/docs/PERF_BUDGET.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "iterations_ci": 120000,
+  "thresholds": {
+    "scheduler_next": {
+      "min_ops_per_sec": 10000.0,
+      "max_ns_per_op": 100000.0
+    },
+    "namespace_translate_local_to_global": {
+      "min_ops_per_sec": 10000.0,
+      "max_ns_per_op": 100000.0
+    },
+    "namespace_can_inspect": {
+      "min_ops_per_sec": 10000.0,
+      "max_ns_per_op": 100000.0
+    },
+    "ipc_reserve_send_plus_drain": {
+      "min_ops_per_sec": 10000.0,
+      "max_ns_per_op": 100000.0
+    },
+    "memory_charge_plus_release": {
+      "min_ops_per_sec": 10000.0,
+      "max_ns_per_op": 100000.0
+    }
+  }
+}

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -71,3 +71,9 @@ Kernel direction, interfaces, and implementation notes live here.
   - exposes lookup-cache hit/miss telemetry in namespace snapshot JSON.
   - tracks attach/detach/translate/inspect failure counters for error-path observability.
   - tracks namespace cache invalidation count to expose mutation churn.
+
+## Performance Governance
+
+- cross-module hotpath benchmark source: `tools/benchmarks/kernel_hotpath_bench.c`
+- local runner: `python scripts/kernel_hotpath_benchmark.py --iterations 200000`
+- CI budget gate: `.github/workflows/perf-budget.yml` with thresholds in `docs/PERF_BUDGET.json`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,3 +24,5 @@ Helper scripts for local development and automation live here.
 - `package_signature_verifier.py`: verifies HMAC-SHA256 package signatures from repository index entries using keyring input.
 - `sandbox_escape_fuzz_corpus.py`: generates deterministic path+DNS sandbox-escape fuzz corpus from seed sets with reason-coded expected blocks.
 - `scheduler_turbo_benchmark.py`: deterministic benchmark comparing round-robin vs turbo scheduler latency metrics.
+- `kernel_hotpath_benchmark.py`: compiles/runs cross-module kernel hotpath microbenchmark (scheduler/namespace/ipc/memory) and emits JSON metrics.
+- `kernel_perf_budget_gate.py`: enforces `docs/PERF_BUDGET.json` thresholds using benchmark output, supports emitting benchmark JSON artifact for CI.

--- a/scripts/kernel_hotpath_benchmark.py
+++ b/scripts/kernel_hotpath_benchmark.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+
+def _repo_root() -> Path:
+  return Path(__file__).resolve().parents[1]
+
+
+def _pick_compiler(preferred: str | None) -> List[str]:
+  compilers: List[str] = []
+  if preferred:
+    compilers.append(preferred)
+  compilers.extend(["clang", "gcc", "cc"])
+  seen = set()
+  unique: List[str] = []
+  for c in compilers:
+    if c in seen:
+      continue
+    seen.add(c)
+    unique.append(c)
+  return unique
+
+
+def _binary_path(root: Path) -> Path:
+  name = "out_kernel_hotpath_bench"
+  if os.name == "nt":
+    name += ".exe"
+  return root / name
+
+
+def _compile(root: Path, compiler: str, output: Path) -> None:
+  sources = [
+      root / "tools" / "benchmarks" / "kernel_hotpath_bench.c",
+      root / "kernel" / "src" / "kernel_main.c",
+      root / "kernel" / "src" / "process_checkpoint.c",
+      root / "kernel" / "src" / "secure_time_attestation.c",
+  ]
+  cmd = [
+      compiler,
+      "-std=c11",
+      "-O2",
+      "-Wall",
+      "-Wextra",
+      "-Wpedantic",
+      "-Ikernel/include",
+      *[str(s) for s in sources],
+      "-o",
+      str(output),
+  ]
+  subprocess.run(cmd, cwd=root, check=True)
+
+
+def run_benchmark(iterations: int, compiler: str | None = None) -> dict:
+  root = _repo_root()
+  output = _binary_path(root)
+  compile_errors: List[str] = []
+
+  for c in _pick_compiler(compiler):
+    try:
+      _compile(root, c, output)
+      break
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+      compile_errors.append(f"{c}: {exc}")
+  else:
+    raise RuntimeError("failed to compile benchmark binary: " + " | ".join(compile_errors))
+
+  result = subprocess.run([str(output), str(iterations)], cwd=root, check=True, text=True, capture_output=True)
+  data = json.loads(result.stdout)
+  if not isinstance(data, dict) or data.get("schema_version") != 1:
+    raise RuntimeError("unexpected benchmark JSON schema")
+  return data
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Run kernel cross-module hotpath benchmark and emit JSON.")
+  parser.add_argument("--iterations", type=int, default=200000)
+  parser.add_argument("--compiler", default=None)
+  parser.add_argument("--output", default=None, help="Optional output JSON path")
+  args = parser.parse_args()
+
+  if args.iterations <= 0:
+    raise ValueError("iterations must be > 0")
+
+  data = run_benchmark(iterations=args.iterations, compiler=args.compiler)
+  payload = json.dumps(data, sort_keys=True, separators=(",", ":"))
+  if args.output:
+    Path(args.output).write_text(payload + "\n", encoding="utf-8")
+  print(payload)
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/kernel_perf_budget_gate.py
+++ b/scripts/kernel_perf_budget_gate.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_json(path: Path) -> dict:
+  data = json.loads(path.read_text(encoding="utf-8"))
+  if not isinstance(data, dict):
+    raise ValueError(f"invalid JSON object in {path}")
+  return data
+
+
+def _run_benchmark(repo_root: Path, iterations: int) -> dict:
+  cmd = [
+      sys.executable,
+      str(repo_root / "scripts" / "kernel_hotpath_benchmark.py"),
+      "--iterations",
+      str(iterations),
+  ]
+  result = subprocess.run(cmd, cwd=repo_root, check=True, capture_output=True, text=True)
+  data = json.loads(result.stdout)
+  if not isinstance(data, dict):
+    raise ValueError("benchmark output was not an object")
+  return data
+
+
+def _check_thresholds(bench: dict, budget: dict) -> list[str]:
+  failures: list[str] = []
+  thresholds = budget.get("thresholds", {})
+  if not isinstance(thresholds, dict):
+    return ["budget thresholds missing or invalid"]
+
+  for metric_name, metric_budget in thresholds.items():
+    if not isinstance(metric_budget, dict):
+      failures.append(f"threshold {metric_name} has invalid config")
+      continue
+    metric = bench.get(metric_name)
+    if not isinstance(metric, dict):
+      failures.append(f"benchmark metric missing: {metric_name}")
+      continue
+
+    ops_per_sec = float(metric.get("ops_per_sec", 0.0))
+    ns_per_op = float(metric.get("ns_per_op", 0.0))
+    min_ops_per_sec = float(metric_budget.get("min_ops_per_sec", 0.0))
+    max_ns_per_op = float(metric_budget.get("max_ns_per_op", float("inf")))
+
+    if ops_per_sec < min_ops_per_sec:
+      failures.append(
+          f"{metric_name}: ops_per_sec {ops_per_sec:.3f} below min {min_ops_per_sec:.3f}"
+      )
+    if ns_per_op > max_ns_per_op:
+      failures.append(
+          f"{metric_name}: ns_per_op {ns_per_op:.3f} above max {max_ns_per_op:.3f}"
+      )
+  return failures
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Kernel perf budget gate for cross-module hotpath benchmark.")
+  parser.add_argument("--budget", default="docs/PERF_BUDGET.json")
+  parser.add_argument("--benchmark-json", default=None,
+                      help="Optional precomputed benchmark JSON path. If omitted, benchmark is executed.")
+  parser.add_argument("--emit-benchmark-json", default=None,
+                      help="Optional output path to write benchmark payload used by this gate.")
+  args = parser.parse_args()
+
+  repo_root = Path(__file__).resolve().parents[1]
+  budget_path = repo_root / args.budget
+  budget = _load_json(budget_path)
+  if int(budget.get("schema_version", 0)) != 1:
+    raise ValueError("unsupported PERF_BUDGET schema_version")
+
+  if args.benchmark_json:
+    bench = _load_json(repo_root / args.benchmark_json)
+  else:
+    iterations = int(budget.get("iterations_ci", 120000))
+    bench = _run_benchmark(repo_root, iterations)
+
+  if args.emit_benchmark_json:
+    out_path = repo_root / args.emit_benchmark_json
+    out_path.write_text(json.dumps(bench, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+
+  failures = _check_thresholds(bench, budget)
+  if failures:
+    print("Kernel perf budget gate: FAILED")
+    for line in failures:
+      print(f"- {line}")
+    return 1
+
+  print("Kernel perf budget gate: PASSED")
+  print(json.dumps(bench, sort_keys=True, separators=(",", ":")))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/tools/benchmarks/kernel_hotpath_bench.c
+++ b/tools/benchmarks/kernel_hotpath_bench.c
@@ -1,0 +1,278 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <time.h>
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+#include "kernel.h"
+
+typedef struct {
+  uint64_t total_ns;
+  double ns_per_op;
+  double ops_per_sec;
+} bench_result_t;
+
+static uint64_t now_ns(void) {
+#if defined(_WIN32)
+  LARGE_INTEGER counter;
+  LARGE_INTEGER frequency;
+  if (!QueryPerformanceFrequency(&frequency)) {
+    return 0u;
+  }
+  if (!QueryPerformanceCounter(&counter)) {
+    return 0u;
+  }
+  return (uint64_t)((counter.QuadPart * 1000000000ull) / (uint64_t)frequency.QuadPart);
+#else
+#if defined(CLOCK_MONOTONIC)
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+  }
+#endif
+  clock_t ticks = clock();
+  if (ticks < 0) {
+    return 0u;
+  }
+  return (uint64_t)(((double)ticks * 1000000000.0) / (double)CLOCKS_PER_SEC);
+#endif
+}
+
+static bench_result_t build_result(uint64_t elapsed_ns, uint32_t iterations) {
+  bench_result_t out;
+  out.total_ns = elapsed_ns;
+  if (iterations == 0u || elapsed_ns == 0u) {
+    out.ns_per_op = 0.0;
+    out.ops_per_sec = 0.0;
+    return out;
+  }
+  out.ns_per_op = (double)elapsed_ns / (double)iterations;
+  out.ops_per_sec = ((double)iterations * 1000000000.0) / (double)elapsed_ns;
+  return out;
+}
+
+static int run_scheduler_bench(uint32_t iterations, bench_result_t *out) {
+  aegis_scheduler_t scheduler;
+  uint32_t pid = 0u;
+  uint64_t start_ns;
+  uint64_t end_ns;
+  uint32_t i;
+
+  if (out == 0 || iterations == 0u) {
+    return -1;
+  }
+
+  aegis_scheduler_init(&scheduler);
+  for (i = 0u; i < 32u; ++i) {
+    uint8_t priority = (uint8_t)((i % 3u) + 1u);
+    if (aegis_scheduler_add_with_priority(&scheduler, 20000u + i, priority) != 0) {
+      return -1;
+    }
+  }
+
+  start_ns = now_ns();
+  for (i = 0u; i < iterations; ++i) {
+    scheduler.scheduler_ticks += 1u;
+    if (aegis_scheduler_next(&scheduler, &pid) != 0) {
+      return -1;
+    }
+  }
+  end_ns = now_ns();
+  *out = build_result(end_ns - start_ns, iterations);
+  return 0;
+}
+
+static int run_namespace_translate_bench(uint32_t iterations, bench_result_t *out) {
+  aegis_namespace_table_t table;
+  uint32_t namespace_id = 0u;
+  uint32_t local_pid = 0u;
+  uint32_t global_pid = 0u;
+  uint64_t start_ns;
+  uint64_t end_ns;
+  uint32_t i;
+
+  if (out == 0 || iterations == 0u) {
+    return -1;
+  }
+
+  aegis_namespace_table_init(&table);
+  if (aegis_namespace_create(&table, 1u, &namespace_id) != 0) {
+    return -1;
+  }
+  if (aegis_namespace_attach_process(&table, 30001u, namespace_id, &local_pid) != 0) {
+    return -1;
+  }
+
+  start_ns = now_ns();
+  for (i = 0u; i < iterations; ++i) {
+    if (aegis_namespace_translate_local_to_global(&table, namespace_id, local_pid, &global_pid) != 0) {
+      return -1;
+    }
+  }
+  end_ns = now_ns();
+
+  if (global_pid != 30001u) {
+    return -1;
+  }
+
+  *out = build_result(end_ns - start_ns, iterations);
+  return 0;
+}
+
+static int run_namespace_inspect_bench(uint32_t iterations, bench_result_t *out) {
+  aegis_namespace_table_t table;
+  uint32_t namespace_id = 0u;
+  uint32_t local_pid = 0u;
+  uint32_t local_pid_2 = 0u;
+  uint8_t allowed = 0u;
+  uint64_t start_ns;
+  uint64_t end_ns;
+  uint32_t i;
+
+  if (out == 0 || iterations == 0u) {
+    return -1;
+  }
+
+  aegis_namespace_table_init(&table);
+  if (aegis_namespace_create(&table, 1u, &namespace_id) != 0) {
+    return -1;
+  }
+  if (aegis_namespace_attach_process(&table, 31001u, namespace_id, &local_pid) != 0 ||
+      aegis_namespace_attach_process(&table, 31002u, namespace_id, &local_pid_2) != 0) {
+    return -1;
+  }
+
+  if (aegis_namespace_can_inspect(&table, 31001u, 31002u, &allowed) != 0 || allowed == 0u) {
+    return -1;
+  }
+
+  start_ns = now_ns();
+  for (i = 0u; i < iterations; ++i) {
+    if (aegis_namespace_can_inspect(&table, 31001u, 31002u, &allowed) != 0) {
+      return -1;
+    }
+  }
+  end_ns = now_ns();
+
+  if (allowed == 0u || local_pid == 0u || local_pid_2 == 0u) {
+    return -1;
+  }
+
+  *out = build_result(end_ns - start_ns, iterations);
+  return 0;
+}
+
+static int run_ipc_hotpath_bench(uint32_t iterations, bench_result_t *out) {
+  aegis_ipc_channel_table_t table;
+  uint8_t accepted = 0u;
+  uint64_t start_ns;
+  uint64_t end_ns;
+  uint32_t i;
+
+  if (out == 0 || iterations == 0u) {
+    return -1;
+  }
+
+  aegis_ipc_channel_table_init(&table);
+  if (aegis_ipc_channel_configure(&table, 77u, 1024u) != 0) {
+    return -1;
+  }
+
+  start_ns = now_ns();
+  for (i = 0u; i < iterations; ++i) {
+    if (aegis_ipc_channel_reserve_send(&table, 77u, 32u, &accepted) < 0 || accepted == 0u) {
+      return -1;
+    }
+    if (aegis_ipc_channel_drain(&table, 77u, 32u) != 0) {
+      return -1;
+    }
+  }
+  end_ns = now_ns();
+
+  *out = build_result(end_ns - start_ns, iterations);
+  return 0;
+}
+
+static int run_memory_hotpath_bench(uint32_t iterations, bench_result_t *out) {
+  aegis_memory_zone_table_t table;
+  uint8_t accepted = 0u;
+  uint64_t start_ns;
+  uint64_t end_ns;
+  uint32_t i;
+
+  if (out == 0 || iterations == 0u) {
+    return -1;
+  }
+
+  aegis_memory_zone_table_init(&table);
+  if (aegis_memory_zone_configure(&table, 9u, AEGIS_MEMORY_ZONE_USER, 1024u * 1024u) != 0) {
+    return -1;
+  }
+
+  start_ns = now_ns();
+  for (i = 0u; i < iterations; ++i) {
+    if (aegis_memory_zone_charge(&table, 9u, 64u, &accepted) < 0 || accepted == 0u) {
+      return -1;
+    }
+    if (aegis_memory_zone_release(&table, 9u, 64u) != 0) {
+      return -1;
+    }
+  }
+  end_ns = now_ns();
+
+  *out = build_result(end_ns - start_ns, iterations);
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  uint32_t iterations = 200000u;
+  bench_result_t scheduler_result;
+  bench_result_t namespace_translate_result;
+  bench_result_t namespace_inspect_result;
+  bench_result_t ipc_result;
+  bench_result_t memory_result;
+
+  if (argc > 1) {
+    unsigned long parsed = strtoul(argv[1], 0, 10);
+    if (parsed == 0ul || parsed > 20000000ul) {
+      fprintf(stderr, "invalid iterations value\n");
+      return 2;
+    }
+    iterations = (uint32_t)parsed;
+  }
+
+  if (run_scheduler_bench(iterations, &scheduler_result) != 0 ||
+      run_namespace_translate_bench(iterations, &namespace_translate_result) != 0 ||
+      run_namespace_inspect_bench(iterations, &namespace_inspect_result) != 0 ||
+      run_ipc_hotpath_bench(iterations, &ipc_result) != 0 ||
+      run_memory_hotpath_bench(iterations, &memory_result) != 0) {
+    fprintf(stderr, "benchmark execution failed\n");
+    return 1;
+  }
+
+  printf("{\"schema_version\":1,\"iterations\":%u,"
+         "\"scheduler_next\":{\"total_ns\":%llu,\"ns_per_op\":%.3f,\"ops_per_sec\":%.3f},"
+         "\"namespace_translate_local_to_global\":{\"total_ns\":%llu,\"ns_per_op\":%.3f,\"ops_per_sec\":%.3f},"
+         "\"namespace_can_inspect\":{\"total_ns\":%llu,\"ns_per_op\":%.3f,\"ops_per_sec\":%.3f},"
+         "\"ipc_reserve_send_plus_drain\":{\"total_ns\":%llu,\"ns_per_op\":%.3f,\"ops_per_sec\":%.3f},"
+         "\"memory_charge_plus_release\":{\"total_ns\":%llu,\"ns_per_op\":%.3f,\"ops_per_sec\":%.3f}}\n",
+         iterations,
+         (unsigned long long)scheduler_result.total_ns,
+         scheduler_result.ns_per_op,
+         scheduler_result.ops_per_sec,
+         (unsigned long long)namespace_translate_result.total_ns,
+         namespace_translate_result.ns_per_op,
+         namespace_translate_result.ops_per_sec,
+         (unsigned long long)namespace_inspect_result.total_ns,
+         namespace_inspect_result.ns_per_op,
+         namespace_inspect_result.ops_per_sec,
+         (unsigned long long)ipc_result.total_ns,
+         ipc_result.ns_per_op,
+         ipc_result.ops_per_sec,
+         (unsigned long long)memory_result.total_ns,
+         memory_result.ns_per_op,
+         memory_result.ops_per_sec);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add cross-module kernel hotpath microbenchmark source at 	ools/benchmarks/kernel_hotpath_bench.c
- add benchmark runner CLI scripts/kernel_hotpath_benchmark.py that compiles/runs and emits JSON
- add perf budget profile docs/PERF_BUDGET.json
- add budget enforcement script scripts/kernel_perf_budget_gate.py
- add dedicated CI workflow .github/workflows/perf-budget.yml with benchmark artifact upload
- document local benchmark/gate usage in root/kernel/scripts docs

## Validation
- python scripts/kernel_perf_budget_gate.py --emit-benchmark-json out_kernel_hotpath_bench.json
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

Closes #237
Closes #238