### PR TITLE
Memory pressure API + secure-time nonce window saturation stats (#234 #235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ This repository contains:
 - IPC burst-budget autotune with up/down adjustment telemetry for sustained burst workloads.
 - Memory unknown-zone request, release-underflow clamp, and reclaim-shortfall telemetry in zone snapshots.
 - Memory-zone reclaim efficiency scoring (`current` + `EMA`) in zone telemetry.
+- Memory pressure level API (`low`/`medium`/`high`) for policy loops and adaptive throttling.
 - Scheduler PID lookup upgraded to dual-entry cache (primary + victim) to reduce repeated linear scans.
 - Scheduler dispatch scan-depth telemetry to quantify round-robin/turbo hot-path scan cost.
 - Scheduler ready-bitmap popcount fastpath for single-class runnable dispatch cycles.
 - Namespace requester/target inspect-pair cache fastpath with hit/miss telemetry.
+- Secure-time nonce-window saturation counters in attestor snapshots (`inserts`, `overwrites`, `high_watermark`).
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).
 - Installer secure bootstrap state machine with recovery and attestation hook gates.
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -54,6 +54,7 @@ Kernel direction, interfaces, and implementation notes live here.
 - `aegis_secure_time_attestor_t`:
   - includes nonce lookup-cache fast path for repeated nonce-replay checks.
   - tracks drift-budget clamp events and nonce cache hit/miss telemetry in snapshot JSON.
+  - tracks nonce-window saturation telemetry (`inserts`, `overwrites`, `high_watermark`) for replay-window observability.
 - `aegis_syscall_gate_matrix_t`: syscall capability enforcement matrix.
   - includes decision-cache fast path for hot process/syscall pairs.
   - includes process/rule lookup-cache fast paths to reduce repeated linear scans.
@@ -67,6 +68,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - include IPC burst-budget autotune (quota up/down adjustments) based on sustained pressure/drain behavior.
   - include memory unknown-zone, release-underflow clamp, and reclaim-shortfall counters.
   - include per-zone reclaim efficiency telemetry (current + EMA) for reclaim policy tuning.
+  - expose memory pressure level helper API (`low`/`medium`/`high`) for userland policy loops.
 - `aegis_namespace_table_t`:
   - includes lookup-cache fast paths for local/global pid translation.
   - includes requester/target inspect-pair cache fastpath for repeated visibility checks.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -295,6 +295,12 @@ typedef enum {
   AEGIS_MEMORY_ZONE_CACHE = 4
 } aegis_memory_zone_kind_t;
 
+typedef enum {
+  AEGIS_MEMORY_PRESSURE_LOW = 1,
+  AEGIS_MEMORY_PRESSURE_MEDIUM = 2,
+  AEGIS_MEMORY_PRESSURE_HIGH = 3
+} aegis_memory_pressure_level_t;
+
 typedef struct {
   uint32_t zone_id;
   uint8_t zone_kind;
@@ -398,6 +404,10 @@ typedef struct {
   uint8_t nonce_lookup_cache_valid;
   uint64_t nonce_lookup_cache_hits;
   uint64_t nonce_lookup_cache_misses;
+  uint64_t nonce_window_inserts;
+  uint64_t nonce_window_overwrites;
+  uint64_t nonce_window_saturation_events;
+  uint8_t nonce_window_high_watermark;
   uint64_t drift_budget_clamp_events;
   uint8_t initialized;
 } aegis_secure_time_attestor_t;
@@ -637,6 +647,9 @@ int aegis_memory_zone_charge(aegis_memory_zone_table_t *table,
 int aegis_memory_zone_release(aegis_memory_zone_table_t *table,
                               uint32_t zone_id,
                               uint64_t bytes);
+int aegis_memory_zone_pressure_level(const aegis_memory_zone_table_t *table,
+                                     uint32_t zone_id,
+                                     uint8_t *level_out);
 int aegis_memory_zone_snapshot_json(const aegis_memory_zone_table_t *table,
                                     char *out,
                                     size_t out_size);

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -3396,6 +3396,36 @@ int aegis_memory_zone_release(aegis_memory_zone_table_t *table,
   return 0;
 }
 
+int aegis_memory_zone_pressure_level(const aegis_memory_zone_table_t *table,
+                                     uint32_t zone_id,
+                                     uint8_t *level_out) {
+  size_t idx = 0u;
+  uint64_t budget = 0u;
+  uint64_t used = 0u;
+  uint64_t ratio_bps = 0u;
+  if (table == 0 || zone_id == 0u || level_out == 0) {
+    return -1;
+  }
+  if (!memory_zone_find_index(table, zone_id, &idx)) {
+    return -1;
+  }
+  budget = table->zones[idx].budget_bytes;
+  used = table->zones[idx].used_bytes;
+  if (budget == 0u) {
+    *level_out = AEGIS_MEMORY_PRESSURE_HIGH;
+    return 0;
+  }
+  ratio_bps = (used * 10000ull) / budget;
+  if (ratio_bps >= 8500ull) {
+    *level_out = AEGIS_MEMORY_PRESSURE_HIGH;
+  } else if (ratio_bps >= 6000ull) {
+    *level_out = AEGIS_MEMORY_PRESSURE_MEDIUM;
+  } else {
+    *level_out = AEGIS_MEMORY_PRESSURE_LOW;
+  }
+  return 0;
+}
+
 int aegis_memory_zone_snapshot_json(const aegis_memory_zone_table_t *table,
                                     char *out,
                                     size_t out_size) {
@@ -3428,9 +3458,11 @@ int aegis_memory_zone_snapshot_json(const aegis_memory_zone_table_t *table,
   offset = (size_t)written;
   for (i = 0; i < AEGIS_MEMORY_ZONE_CAPACITY; ++i) {
     const aegis_memory_zone_t *zone = &table->zones[i];
+    uint8_t pressure_level = AEGIS_MEMORY_PRESSURE_LOW;
     if (zone->active == 0u) {
       continue;
     }
+    (void)aegis_memory_zone_pressure_level(table, zone->zone_id, &pressure_level);
     written = snprintf(
         out + offset,
         out_size - offset,
@@ -3438,7 +3470,8 @@ int aegis_memory_zone_snapshot_json(const aegis_memory_zone_table_t *table,
         "\"high_watermark_bytes\":%llu,\"reclaim_target_bytes\":%llu,\"reclaim_attempts\":%llu,"
         "\"reclaim_successes\":%llu,\"reclaim_bytes_attempted\":%llu,"
         "\"reclaim_bytes_recovered\":%llu,\"reclaim_efficiency_bps\":%u,"
-        "\"reclaim_efficiency_bps_ema\":%u,\"reclaim_hook_enabled\":%u}",
+        "\"reclaim_efficiency_bps_ema\":%u,\"pressure_level\":%u,"
+        "\"reclaim_hook_enabled\":%u}",
         first ? "" : ",",
         zone->zone_id,
         (unsigned int)zone->zone_kind,
@@ -3452,6 +3485,7 @@ int aegis_memory_zone_snapshot_json(const aegis_memory_zone_table_t *table,
         (unsigned long long)zone->reclaim_bytes_recovered,
         (unsigned int)zone->reclaim_efficiency_bps,
         (unsigned int)zone->reclaim_efficiency_bps_ema,
+        (unsigned int)pressure_level,
         (unsigned int)zone->reclaim_hook_enabled);
     if (written < 0 || (size_t)written >= (out_size - offset)) {
       return -1;

--- a/kernel/src/secure_time_attestation.c
+++ b/kernel/src/secure_time_attestation.c
@@ -36,11 +36,20 @@ static void nonce_record(aegis_secure_time_attestor_t *attestor, const char *non
   if (attestor == 0 || nonce == 0 || nonce[0] == '\0') {
     return;
   }
+  if (attestor->recent_nonce_count >= 8u) {
+    attestor->nonce_window_overwrites += 1u;
+    attestor->nonce_window_saturation_events += 1u;
+  } else {
+    attestor->nonce_window_inserts += 1u;
+  }
   head = attestor->recent_nonce_head % 8u;
   snprintf(attestor->recent_nonces[head], sizeof(attestor->recent_nonces[head]), "%s", nonce);
   attestor->recent_nonce_head = (uint8_t)((head + 1u) % 8u);
   if (attestor->recent_nonce_count < 8u) {
     attestor->recent_nonce_count += 1u;
+  }
+  if (attestor->recent_nonce_count > attestor->nonce_window_high_watermark) {
+    attestor->nonce_window_high_watermark = attestor->recent_nonce_count;
   }
   snprintf(attestor->nonce_lookup_cache, sizeof(attestor->nonce_lookup_cache), "%s", nonce);
   attestor->nonce_lookup_cache_valid = 1u;
@@ -185,7 +194,9 @@ int aegis_secure_time_attestor_snapshot_json(const aegis_secure_time_attestor_t 
                      "\"attestations_ok\":%llu,\"attestations_failed\":%llu,"
                      "\"rollback_detected\":%llu,\"drift_violations\":%llu,"
                      "\"nonce_replay_detected\":%llu,\"nonce_lookup_cache_hits\":%llu,"
-                     "\"nonce_lookup_cache_misses\":%llu,\"drift_budget_clamp_events\":%llu}",
+                     "\"nonce_lookup_cache_misses\":%llu,\"nonce_window_inserts\":%llu,"
+                     "\"nonce_window_overwrites\":%llu,\"nonce_window_saturation_events\":%llu,"
+                     "\"nonce_window_high_watermark\":%u,\"drift_budget_clamp_events\":%llu}",
                      (unsigned int)attestor->boot_id,
                      (unsigned long long)attestor->last_wallclock_epoch,
                      (unsigned long long)attestor->last_monotonic_tick,
@@ -197,6 +208,10 @@ int aegis_secure_time_attestor_snapshot_json(const aegis_secure_time_attestor_t 
                      (unsigned long long)attestor->nonce_replay_detected,
                      (unsigned long long)attestor->nonce_lookup_cache_hits,
                      (unsigned long long)attestor->nonce_lookup_cache_misses,
+                     (unsigned long long)attestor->nonce_window_inserts,
+                     (unsigned long long)attestor->nonce_window_overwrites,
+                     (unsigned long long)attestor->nonce_window_saturation_events,
+                     (unsigned int)attestor->nonce_window_high_watermark,
                      (unsigned long long)attestor->drift_budget_clamp_events);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -1057,6 +1057,7 @@ static int test_ipc_channel_quota_and_backpressure(void) {
 static int test_memory_zone_accounting_and_reclaim_hooks(void) {
   aegis_memory_zone_table_t table;
   uint8_t accepted = 0u;
+  uint8_t pressure = 0u;
   char json[4096];
   char tiny[32];
   aegis_memory_zone_table_init(&table);
@@ -1105,6 +1106,11 @@ static int test_memory_zone_accounting_and_reclaim_hooks(void) {
     fprintf(stderr, "memory zone release underflow clamp path failed\n");
     return 1;
   }
+  if (aegis_memory_zone_pressure_level(&table, 1u, &pressure) != 0 ||
+      pressure != AEGIS_MEMORY_PRESSURE_LOW) {
+    fprintf(stderr, "memory zone pressure level expected low after release\n");
+    return 1;
+  }
   if (aegis_memory_zone_snapshot_json(&table, json, sizeof(json)) <= 0 ||
       strstr(json, "\"schema_version\":1") == 0 ||
       strstr(json, "\"denied_charges\":2") == 0 ||
@@ -1119,12 +1125,50 @@ static int test_memory_zone_accounting_and_reclaim_hooks(void) {
       strstr(json, "\"reclaim_bytes_attempted\":512") == 0 ||
       strstr(json, "\"reclaim_bytes_recovered\":512") == 0 ||
       strstr(json, "\"reclaim_efficiency_bps\":10000") == 0 ||
-      strstr(json, "\"reclaim_efficiency_bps_ema\":10000") == 0) {
+      strstr(json, "\"reclaim_efficiency_bps_ema\":10000") == 0 ||
+      strstr(json, "\"pressure_level\":1") == 0) {
     fprintf(stderr, "memory zone snapshot mismatch: %s\n", json);
     return 1;
   }
   if (aegis_memory_zone_snapshot_json(&table, tiny, sizeof(tiny)) >= 0) {
     fprintf(stderr, "expected tiny memory zone snapshot failure\n");
+    return 1;
+  }
+  return 0;
+}
+
+static int test_memory_zone_pressure_level_api(void) {
+  aegis_memory_zone_table_t table;
+  uint8_t accepted = 0u;
+  uint8_t pressure = 0u;
+  aegis_memory_zone_table_init(&table);
+  if (aegis_memory_zone_configure(&table, 44u, AEGIS_MEMORY_ZONE_USER, 1000u) != 0) {
+    fprintf(stderr, "memory pressure api configure failed\n");
+    return 1;
+  }
+  if (aegis_memory_zone_charge(&table, 44u, 500u, &accepted) != 1 ||
+      accepted != 1u ||
+      aegis_memory_zone_pressure_level(&table, 44u, &pressure) != 0 ||
+      pressure != AEGIS_MEMORY_PRESSURE_LOW) {
+    fprintf(stderr, "memory pressure api low level mismatch\n");
+    return 1;
+  }
+  if (aegis_memory_zone_charge(&table, 44u, 150u, &accepted) != 1 ||
+      accepted != 1u ||
+      aegis_memory_zone_pressure_level(&table, 44u, &pressure) != 0 ||
+      pressure != AEGIS_MEMORY_PRESSURE_MEDIUM) {
+    fprintf(stderr, "memory pressure api medium level mismatch\n");
+    return 1;
+  }
+  if (aegis_memory_zone_charge(&table, 44u, 250u, &accepted) != 1 ||
+      accepted != 1u ||
+      aegis_memory_zone_pressure_level(&table, 44u, &pressure) != 0 ||
+      pressure != AEGIS_MEMORY_PRESSURE_HIGH) {
+    fprintf(stderr, "memory pressure api high level mismatch\n");
+    return 1;
+  }
+  if (aegis_memory_zone_pressure_level(&table, 999u, &pressure) == 0) {
+    fprintf(stderr, "memory pressure api unknown zone should fail\n");
     return 1;
   }
   return 0;
@@ -2054,8 +2098,40 @@ static int test_secure_time_source_attestation(void) {
       strstr(snapshot_json, "\"nonce_replay_detected\":1") == 0 ||
       strstr(snapshot_json, "\"nonce_lookup_cache_hits\":1") == 0 ||
       strstr(snapshot_json, "\"nonce_lookup_cache_misses\":3") == 0 ||
+      strstr(snapshot_json, "\"nonce_window_inserts\":1") == 0 ||
+      strstr(snapshot_json, "\"nonce_window_overwrites\":0") == 0 ||
+      strstr(snapshot_json, "\"nonce_window_saturation_events\":0") == 0 ||
+      strstr(snapshot_json, "\"nonce_window_high_watermark\":1") == 0 ||
       strstr(snapshot_json, "\"drift_budget_clamp_events\":0") == 0) {
     fprintf(stderr, "secure time snapshot mismatch: %s\n", snapshot_json);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_secure_time_nonce_window_saturation_stats(void) {
+  aegis_secure_time_attestor_t attestor;
+  aegis_secure_time_attestation_result_t result;
+  char nonce[32];
+  char snapshot_json[1024];
+  uint32_t i;
+  memset(&attestor, 0, sizeof(attestor));
+  memset(&result, 0, sizeof(result));
+  aegis_secure_time_attestor_init(&attestor, 99u, 1800000000u, 500u, 1000000u);
+  for (i = 1u; i <= 10u; ++i) {
+    snprintf(nonce, sizeof(nonce), "n-%u", i);
+    if (aegis_secure_time_attest(&attestor, 1800000000u + i, 500u + i, nonce, &result) != 1 ||
+        result.accepted != 1u) {
+      fprintf(stderr, "secure time saturation setup attest failed at %u\n", i);
+      return 1;
+    }
+  }
+  if (aegis_secure_time_attestor_snapshot_json(&attestor, snapshot_json, sizeof(snapshot_json)) <= 0 ||
+      strstr(snapshot_json, "\"nonce_window_inserts\":8") == 0 ||
+      strstr(snapshot_json, "\"nonce_window_overwrites\":2") == 0 ||
+      strstr(snapshot_json, "\"nonce_window_saturation_events\":2") == 0 ||
+      strstr(snapshot_json, "\"nonce_window_high_watermark\":8") == 0) {
+    fprintf(stderr, "secure time saturation snapshot mismatch: %s\n", snapshot_json);
     return 1;
   }
   return 0;
@@ -2143,6 +2219,9 @@ int main(void) {
   if (test_memory_zone_accounting_and_reclaim_hooks() != 0) {
     return 1;
   }
+  if (test_memory_zone_pressure_level_api() != 0) {
+    return 1;
+  }
   if (test_lookup_cache_cross_module_stress() != 0) {
     return 1;
   }
@@ -2186,6 +2265,9 @@ int main(void) {
     return 1;
   }
   if (test_secure_time_source_attestation() != 0) {
+    return 1;
+  }
+  if (test_secure_time_nonce_window_saturation_stats() != 0) {
     return 1;
   }
   puts("kernel simulation check passed");


### PR DESCRIPTION
## Summary
- add memory zone pressure level API (low/medium/high) for policy loops
- include pressure_level in memory zone snapshot entries
- add secure-time nonce window saturation telemetry (inserts, overwrites, saturation_events, high_watermark)
- track nonce window saturation behavior in attestation replay window maintenance
- extend tests for pressure-level transitions and nonce-window saturation counters
- update root/kernel docs for both feature surfaces

## Workflow Safety Check
- verified docs automation recursion guards are intact:
  - uto-docs.yml has paths-ignore for EXPLAIN.md/CHANGELOG.md
  - uto-docs.yml has if: github.actor != 'github-actions[bot]'

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py
- python scripts/validate_snapshot_schema_ledger.py

Closes #234
Closes #235