### PR TITLE
feat: scheduler turbo candidate pressure guard v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This repository contains:
 - Scheduler PID lookup upgraded to dual-entry cache (primary + victim) to reduce repeated linear scans.
 - Scheduler dispatch scan-depth telemetry to quantify round-robin/turbo hot-path scan cost.
 - Scheduler ready-bitmap popcount fastpath for single-class runnable dispatch cycles.
+- Scheduler turbo candidate pressure-guard v2 to avoid over-reusing a dominant cached PID under high dispatch pressure.
 - Namespace requester/target inspect-pair cache fastpath with hit/miss telemetry.
 - Secure-time nonce-window saturation counters in attestor snapshots (`inserts`, `overwrites`, `high_watermark`).
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -41,6 +41,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - PID lookup now uses dual-entry (primary + victim) cache with promotion for repeated churned PID access.
   - includes bulk scheduler operation API (`add/remove/reprioritize`) with execution telemetry counters.
   - turbo scheduler now adapts candidate cache reuse budget by queue pressure and switch patterns.
+  - turbo scheduler includes pressure-guard v2 that invalidates cache reuse for dispatch-dominant cached candidates.
   - turbo scoring now penalizes runaway dispatch dominance to preserve fairness under heavy load.
   - wait-latency accounting includes safety clamps for non-monotonic tick edge cases.
   - includes wait-report snapshot endpoint with capture tick and queue metadata.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -91,6 +91,7 @@ typedef struct {
   uint32_t turbo_candidate_cache_index;
   uint64_t turbo_candidate_cache_hits;
   uint64_t turbo_candidate_cache_misses;
+  uint64_t turbo_pressure_guard_trips;
   uint32_t pid_lookup_cache_process_id;
   uint16_t pid_lookup_cache_index;
   uint8_t pid_lookup_cache_valid;

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -567,11 +567,30 @@ static int scheduler_pick_turbo_index(const aegis_scheduler_t *scheduler, size_t
       scheduler->turbo_candidate_cache_index < scheduler->count &&
       scheduler->turbo_candidate_cache_budget > 0u) {
     size_t cached_idx = scheduler->turbo_candidate_cache_index;
+    uint64_t dominant_dispatches = 0u;
+    size_t dominant_idx = 0u;
+    for (i = 0; i < scheduler->count; ++i) {
+      if (scheduler->dispatch_counts[i] > dominant_dispatches) {
+        dominant_dispatches = scheduler->dispatch_counts[i];
+        dominant_idx = i;
+      }
+    }
+    if (scheduler->count >= 8u &&
+        scheduler->total_dispatches >= (uint64_t)(scheduler->count * 10u) &&
+        dominant_dispatches > 0u &&
+        dominant_idx == cached_idx &&
+        (dominant_dispatches * 100u) >= (scheduler->total_dispatches * 55u)) {
+      ((aegis_scheduler_t *)scheduler)->turbo_pressure_guard_trips += 1u;
+      ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_valid = 0u;
+      ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_budget = 0u;
+    }
     if (scheduler->credits[cached_idx] > 0u) {
-      *index_out = cached_idx;
-      ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_budget -= 1u;
-      ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_hits += 1u;
-      return 1;
+      if (scheduler->turbo_candidate_cache_valid != 0u) {
+        *index_out = cached_idx;
+        ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_budget -= 1u;
+        ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_hits += 1u;
+        return 1;
+      }
     }
   }
   ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_misses += 1u;
@@ -714,6 +733,7 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->turbo_candidate_cache_index = 0u;
   scheduler->turbo_candidate_cache_hits = 0u;
   scheduler->turbo_candidate_cache_misses = 0u;
+  scheduler->turbo_pressure_guard_trips = 0u;
   scheduler->pid_lookup_cache_process_id = 0u;
   scheduler->pid_lookup_cache_index = 0u;
   scheduler->pid_lookup_cache_valid = 0u;
@@ -770,6 +790,7 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->turbo_candidate_cache_budget = 0u;
   scheduler->turbo_candidate_cache_hits = 0u;
   scheduler->turbo_candidate_cache_misses = 0u;
+  scheduler->turbo_pressure_guard_trips = 0u;
   scheduler->pid_lookup_cache_process_id = 0u;
   scheduler->pid_lookup_cache_index = 0u;
   scheduler->pid_lookup_cache_valid = 0u;
@@ -1386,7 +1407,9 @@ int aegis_scheduler_turbo_state_json(const aegis_scheduler_t *scheduler, char *o
                      "\"turbo_priority_weight\":%u,\"turbo_autotune_enabled\":%u,"
                      "\"turbo_autotune_interval_ticks\":%u,\"turbo_autotune_adjustments\":%llu,"
                      "\"turbo_last_pid\":%u,\"turbo_candidate_cache_hits\":%llu,"
-                     "\"turbo_candidate_cache_misses\":%llu,\"turbo_candidate_cache_reuse_budget\":%u}",
+                     "\"turbo_candidate_cache_misses\":%llu,"
+                     "\"turbo_pressure_guard_trips\":%llu,"
+                     "\"turbo_candidate_cache_reuse_budget\":%u}",
                      (unsigned int)scheduler->dispatch_strategy,
                      (unsigned int)scheduler->turbo_wait_weight,
                      (unsigned int)scheduler->turbo_priority_weight,
@@ -1396,6 +1419,7 @@ int aegis_scheduler_turbo_state_json(const aegis_scheduler_t *scheduler, char *o
                      scheduler->turbo_last_pid,
                      (unsigned long long)scheduler->turbo_candidate_cache_hits,
                      (unsigned long long)scheduler->turbo_candidate_cache_misses,
+                     (unsigned long long)scheduler->turbo_pressure_guard_trips,
                      (unsigned int)scheduler->turbo_candidate_cache_budget);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
@@ -1903,6 +1927,7 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      "\"bulk_ops_succeeded\":%llu,\"bulk_ops_failed\":%llu,"
                      "\"bulk_ops_unknown\":%llu,\"bulk_results_dropped\":%llu,"
                      "\"turbo_reuse_budget_adaptations\":%llu,"
+                     "\"turbo_pressure_guard_trips\":%llu,"
                      "\"wait_latency_clamp_events\":%llu,"
                      "\"limits\":{\"high\":%u,\"normal\":%u,\"low\":%u},"
                      "\"counts\":{\"high\":%u,\"normal\":%u,\"low\":%u},"
@@ -1926,6 +1951,7 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      (unsigned long long)scheduler->bulk_ops_unknown,
                      (unsigned long long)scheduler->bulk_results_dropped,
                      (unsigned long long)scheduler->turbo_reuse_budget_adaptations,
+                     (unsigned long long)scheduler->turbo_pressure_guard_trips,
                      (unsigned long long)scheduler->wait_latency_clamp_events,
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_HIGH],
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_NORMAL],

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -1276,6 +1276,46 @@ static int test_scheduler_wait_latency_clamp_and_turbo_adapt(void) {
   return 0;
 }
 
+static int test_scheduler_turbo_pressure_guard_v2(void) {
+  aegis_scheduler_t scheduler;
+  uint32_t pid = 0u;
+  char turbo_json[512];
+  int i;
+  aegis_scheduler_init(&scheduler);
+  aegis_scheduler_enable_turbo(&scheduler, 1u);
+  for (i = 0; i < 10; ++i) {
+    if (aegis_scheduler_add_with_priority(&scheduler, (uint32_t)(15000u + (uint32_t)i),
+                                          AEGIS_PRIORITY_HIGH) != 0) {
+      fprintf(stderr, "turbo pressure guard setup add failed\n");
+      return 1;
+    }
+    scheduler.enqueued_tick[i] = (uint64_t)(1u + (uint32_t)i);
+  }
+  scheduler.total_dispatches = 200u;
+  scheduler.dispatch_counts[0] = 140u;
+  for (i = 1; i < 10; ++i) {
+    scheduler.dispatch_counts[i] = 3u;
+  }
+  scheduler.turbo_candidate_cache_valid = 1u;
+  scheduler.turbo_candidate_cache_index = 0u;
+  scheduler.turbo_candidate_cache_budget = 3u;
+  if (aegis_scheduler_next(&scheduler, &pid) != 0) {
+    fprintf(stderr, "turbo pressure guard next failed\n");
+    return 1;
+  }
+  if (scheduler.turbo_pressure_guard_trips == 0u) {
+    fprintf(stderr, "turbo pressure guard expected trip count > 0\n");
+    return 1;
+  }
+  if (aegis_scheduler_turbo_state_json(&scheduler, turbo_json, sizeof(turbo_json)) <= 0 ||
+      strstr(turbo_json, "\"turbo_pressure_guard_trips\":") == 0 ||
+      strstr(turbo_json, "\"turbo_pressure_guard_trips\":0") != 0) {
+    fprintf(stderr, "turbo pressure guard json mismatch: %s\n", turbo_json);
+    return 1;
+  }
+  return 0;
+}
+
 static int test_lookup_cache_cross_module_stress(void) {
   aegis_namespace_table_t namespaces;
   aegis_ipc_channel_table_t ipc;
@@ -2217,6 +2257,9 @@ int main(void) {
     return 1;
   }
   if (test_scheduler_wait_latency_clamp_and_turbo_adapt() != 0) {
+    return 1;
+  }
+  if (test_scheduler_turbo_pressure_guard_v2() != 0) {
     return 1;
   }
   if (test_namespace_isolation_simulator() != 0) {


### PR DESCRIPTION
## Summary
- add turbo pressure-guard v2 that invalidates cached candidate reuse when dispatch dominance crosses pressure threshold
- add 	urbo_pressure_guard_trips telemetry to turbo state and scheduler admission snapshots
- add regression test coverage for pressure-guard trip behavior
- update README/kernel docs for new scheduler guard behavior

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py
- python scripts/validate_snapshot_schema_ledger.py

## Issues
- closes #226