### PR TITLE
feat: scheduler turbo dynamic fairness floor v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # AegisOS
 
 <p align="center">
-  <img src="assets/images/logo/aegios-logo.svg" alt="Aegios logo" width="220" />
-</p>
-
-<p align="center">
   <img src="assets/images/wiki/ios.svg" alt="iOS" height="40" />
   <img src="assets/images/wiki/linux.svg" alt="Linux" height="40" />
   <img src="assets/images/wiki/windows.svg" alt="Windows" height="40" />
@@ -101,6 +97,7 @@ This repository contains:
 - Scheduler dispatch scan-depth telemetry to quantify round-robin/turbo hot-path scan cost.
 - Scheduler ready-bitmap popcount fastpath for single-class runnable dispatch cycles.
 - Scheduler turbo candidate pressure-guard v2 to avoid over-reusing a dominant cached PID under high dispatch pressure.
+- Scheduler turbo fairness floor v1 to prioritize starved runnable tasks under sustained skewed dispatch pressure.
 - Namespace requester/target inspect-pair cache fastpath with hit/miss telemetry.
 - Secure-time nonce-window saturation counters in attestor snapshots (`inserts`, `overwrites`, `high_watermark`).
 - Permission center policy diff endpoint plus policy-change audit exports (JSON/CSV).

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -42,6 +42,7 @@ Kernel direction, interfaces, and implementation notes live here.
   - includes bulk scheduler operation API (`add/remove/reprioritize`) with execution telemetry counters.
   - turbo scheduler now adapts candidate cache reuse budget by queue pressure and switch patterns.
   - turbo scheduler includes pressure-guard v2 that invalidates cache reuse for dispatch-dominant cached candidates.
+  - turbo scheduler includes fairness floor v1 to boost starved runnable tasks during sustained skewed dispatch.
   - turbo scoring now penalizes runaway dispatch dominance to preserve fairness under heavy load.
   - wait-latency accounting includes safety clamps for non-monotonic tick edge cases.
   - includes wait-report snapshot endpoint with capture tick and queue metadata.

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -92,6 +92,7 @@ typedef struct {
   uint64_t turbo_candidate_cache_hits;
   uint64_t turbo_candidate_cache_misses;
   uint64_t turbo_pressure_guard_trips;
+  uint64_t turbo_fairness_floor_trips;
   uint32_t pid_lookup_cache_process_id;
   uint16_t pid_lookup_cache_index;
   uint8_t pid_lookup_cache_valid;

--- a/kernel/src/kernel_main.c
+++ b/kernel/src/kernel_main.c
@@ -560,6 +560,8 @@ static int scheduler_pick_turbo_index(const aegis_scheduler_t *scheduler, size_t
   int best_score = -2147483647;
   size_t best_index = 0u;
   int found = 0;
+  int best_floor_applied = 0;
+  const uint64_t fairness_wait_floor_ticks = 24u;
   if (scheduler == 0 || index_out == 0 || scheduler->count == 0u) {
     return 0;
   }
@@ -596,7 +598,9 @@ static int scheduler_pick_turbo_index(const aegis_scheduler_t *scheduler, size_t
   ((aegis_scheduler_t *)scheduler)->turbo_candidate_cache_misses += 1u;
   for (i = 0; i < scheduler->count; ++i) {
     uint64_t waited_ticks;
+    uint64_t avg_dispatches;
     int score;
+    int floor_applied = 0;
     if (scheduler->credits[i] == 0u) {
       continue;
     }
@@ -612,19 +616,31 @@ static int scheduler_pick_turbo_index(const aegis_scheduler_t *scheduler, size_t
     if (scheduler->total_dispatches > (uint64_t)(scheduler->count * 8u)) {
       score -= (int)(scheduler->dispatch_counts[i] / 2u);
     }
+    avg_dispatches =
+        scheduler->count > 0u ? (scheduler->total_dispatches / (uint64_t)scheduler->count) : 0u;
+    if (waited_ticks >= fairness_wait_floor_ticks &&
+        scheduler->dispatch_counts[i] + 2u < avg_dispatches) {
+      score += 96;
+      floor_applied = 1;
+    }
     if (scheduler->process_ids[i] == scheduler->turbo_last_pid) {
       score -= 2;
     }
     if (!found || score > best_score ||
+        (score == best_score && floor_applied != 0 && best_floor_applied == 0) ||
         (score == best_score &&
          scheduler->enqueued_tick[i] < scheduler->enqueued_tick[best_index])) {
       found = 1;
       best_score = score;
       best_index = i;
+      best_floor_applied = floor_applied;
     }
   }
   if (!found) {
     return 0;
+  }
+  if (best_floor_applied != 0) {
+    ((aegis_scheduler_t *)scheduler)->turbo_fairness_floor_trips += 1u;
   }
   {
     uint8_t desired_budget = 1u;
@@ -734,6 +750,7 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->turbo_candidate_cache_hits = 0u;
   scheduler->turbo_candidate_cache_misses = 0u;
   scheduler->turbo_pressure_guard_trips = 0u;
+  scheduler->turbo_fairness_floor_trips = 0u;
   scheduler->pid_lookup_cache_process_id = 0u;
   scheduler->pid_lookup_cache_index = 0u;
   scheduler->pid_lookup_cache_valid = 0u;
@@ -791,6 +808,7 @@ void aegis_scheduler_init(aegis_scheduler_t *scheduler) {
   scheduler->turbo_candidate_cache_hits = 0u;
   scheduler->turbo_candidate_cache_misses = 0u;
   scheduler->turbo_pressure_guard_trips = 0u;
+  scheduler->turbo_fairness_floor_trips = 0u;
   scheduler->pid_lookup_cache_process_id = 0u;
   scheduler->pid_lookup_cache_index = 0u;
   scheduler->pid_lookup_cache_valid = 0u;
@@ -1214,6 +1232,8 @@ void aegis_scheduler_reset_metrics(aegis_scheduler_t *scheduler) {
   scheduler->turbo_candidate_cache_budget = 0u;
   scheduler->turbo_candidate_cache_hits = 0u;
   scheduler->turbo_candidate_cache_misses = 0u;
+  scheduler->turbo_pressure_guard_trips = 0u;
+  scheduler->turbo_fairness_floor_trips = 0u;
   scheduler->pid_lookup_cache_valid = 0u;
   scheduler->pid_lookup_cache_victim_valid = 0u;
   scheduler->pid_lookup_cache_hits = 0u;
@@ -1409,6 +1429,7 @@ int aegis_scheduler_turbo_state_json(const aegis_scheduler_t *scheduler, char *o
                      "\"turbo_last_pid\":%u,\"turbo_candidate_cache_hits\":%llu,"
                      "\"turbo_candidate_cache_misses\":%llu,"
                      "\"turbo_pressure_guard_trips\":%llu,"
+                     "\"turbo_fairness_floor_trips\":%llu,"
                      "\"turbo_candidate_cache_reuse_budget\":%u}",
                      (unsigned int)scheduler->dispatch_strategy,
                      (unsigned int)scheduler->turbo_wait_weight,
@@ -1420,6 +1441,7 @@ int aegis_scheduler_turbo_state_json(const aegis_scheduler_t *scheduler, char *o
                      (unsigned long long)scheduler->turbo_candidate_cache_hits,
                      (unsigned long long)scheduler->turbo_candidate_cache_misses,
                      (unsigned long long)scheduler->turbo_pressure_guard_trips,
+                     (unsigned long long)scheduler->turbo_fairness_floor_trips,
                      (unsigned int)scheduler->turbo_candidate_cache_budget);
   if (written < 0 || (size_t)written >= out_size) {
     return -1;
@@ -1928,6 +1950,7 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      "\"bulk_ops_unknown\":%llu,\"bulk_results_dropped\":%llu,"
                      "\"turbo_reuse_budget_adaptations\":%llu,"
                      "\"turbo_pressure_guard_trips\":%llu,"
+                     "\"turbo_fairness_floor_trips\":%llu,"
                      "\"wait_latency_clamp_events\":%llu,"
                      "\"limits\":{\"high\":%u,\"normal\":%u,\"low\":%u},"
                      "\"counts\":{\"high\":%u,\"normal\":%u,\"low\":%u},"
@@ -1952,6 +1975,7 @@ int aegis_scheduler_admission_snapshot_json(const aegis_scheduler_t *scheduler,
                      (unsigned long long)scheduler->bulk_results_dropped,
                      (unsigned long long)scheduler->turbo_reuse_budget_adaptations,
                      (unsigned long long)scheduler->turbo_pressure_guard_trips,
+                     (unsigned long long)scheduler->turbo_fairness_floor_trips,
                      (unsigned long long)scheduler->wait_latency_clamp_events,
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_HIGH],
                      (unsigned int)scheduler->admission_limits[AEGIS_PRIORITY_NORMAL],

--- a/tests/kernel_sim_test.c
+++ b/tests/kernel_sim_test.c
@@ -1316,6 +1316,43 @@ static int test_scheduler_turbo_pressure_guard_v2(void) {
   return 0;
 }
 
+static int test_scheduler_turbo_fairness_floor_v1(void) {
+  aegis_scheduler_t scheduler;
+  uint32_t pid = 0u;
+  char turbo_json[512];
+  aegis_scheduler_init(&scheduler);
+  aegis_scheduler_enable_turbo(&scheduler, 1u);
+  if (aegis_scheduler_add_with_priority(&scheduler, 16001u, AEGIS_PRIORITY_HIGH) != 0 ||
+      aegis_scheduler_add_with_priority(&scheduler, 16002u, AEGIS_PRIORITY_HIGH) != 0 ||
+      aegis_scheduler_add_with_priority(&scheduler, 16003u, AEGIS_PRIORITY_LOW) != 0) {
+    fprintf(stderr, "turbo fairness floor setup add failed\n");
+    return 1;
+  }
+  scheduler.total_dispatches = 120u;
+  scheduler.dispatch_counts[0] = 70u;
+  scheduler.dispatch_counts[1] = 45u;
+  scheduler.dispatch_counts[2] = 1u;
+  scheduler.scheduler_ticks = 200u;
+  scheduler.enqueued_tick[0] = 180u;
+  scheduler.enqueued_tick[1] = 182u;
+  scheduler.enqueued_tick[2] = 150u;
+  if (aegis_scheduler_next(&scheduler, &pid) != 0 || pid != 16003u) {
+    fprintf(stderr, "turbo fairness floor expected to select starving pid 16003\n");
+    return 1;
+  }
+  if (scheduler.turbo_fairness_floor_trips == 0u) {
+    fprintf(stderr, "turbo fairness floor expected trip count > 0\n");
+    return 1;
+  }
+  if (aegis_scheduler_turbo_state_json(&scheduler, turbo_json, sizeof(turbo_json)) <= 0 ||
+      strstr(turbo_json, "\"turbo_fairness_floor_trips\":") == 0 ||
+      strstr(turbo_json, "\"turbo_fairness_floor_trips\":0") != 0) {
+    fprintf(stderr, "turbo fairness floor json mismatch: %s\n", turbo_json);
+    return 1;
+  }
+  return 0;
+}
+
 static int test_lookup_cache_cross_module_stress(void) {
   aegis_namespace_table_t namespaces;
   aegis_ipc_channel_table_t ipc;
@@ -2260,6 +2297,9 @@ int main(void) {
     return 1;
   }
   if (test_scheduler_turbo_pressure_guard_v2() != 0) {
+    return 1;
+  }
+  if (test_scheduler_turbo_fairness_floor_v1() != 0) {
     return 1;
   }
   if (test_namespace_isolation_simulator() != 0) {


### PR DESCRIPTION
## Summary
- add turbo fairness floor v1 in candidate selection to boost starved runnable tasks under skewed dispatch pressure
- add 	urbo_fairness_floor_trips telemetry to turbo and admission snapshots
- add regression test coverage for fairness-floor selection + telemetry
- keep README clean by removing broken top logo block while preserving OS icon strip

## Validation
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py
- python scripts/validate_snapshot_schema_ledger.py

## Issues
- closes #251