### PR TITLE
feat: profile-aware perf budget thresholds and matrix gate

### DIFF
--- a/.github/workflows/perf-budget.yml
+++ b/.github/workflows/perf-budget.yml
@@ -15,6 +15,10 @@ on:
 jobs:
   kernel-perf-budget:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [minimal, desktop, server]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,11 +29,11 @@ jobs:
           python-version: "3.x"
 
       - name: Run kernel perf budget gate
-        run: python scripts/kernel_perf_budget_gate.py --emit-benchmark-json out_kernel_hotpath_bench.json
+        run: python scripts/kernel_perf_budget_gate.py --profile ${{ matrix.profile }} --emit-benchmark-json out_kernel_hotpath_bench_${{ matrix.profile }}.json
 
       - name: Upload benchmark artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: kernel-hotpath-benchmark-json
-          path: out_kernel_hotpath_bench.json
+          name: kernel-hotpath-benchmark-json-${{ matrix.profile }}
+          path: out_kernel_hotpath_bench_${{ matrix.profile }}.json

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ This repository contains:
   - includes trace JSON property smoke profiling for regression triage: [`docs/TRACE_JSON_PROPERTY.md`](docs/TRACE_JSON_PROPERTY.md).
 - [`Kernel Perf Budget workflow`](.github/workflows/perf-budget.yml) runs cross-module hotpath benchmark and fails CI on budget regressions.
   - budget profile: [`docs/PERF_BUDGET.json`](docs/PERF_BUDGET.json).
+  - runs profile-aware gates (`minimal`, `desktop`, `server`) for broader real-world hardware envelopes.
   - local benchmark CLI: `python scripts/kernel_hotpath_benchmark.py --iterations 200000`.
-  - local gate run: `python scripts/kernel_perf_budget_gate.py`.
+  - local gate run: `python scripts/kernel_perf_budget_gate.py --profile desktop`.
 - [`Benchmark Monitor workflow`](.github/workflows/benchmark-monitor.yml) continuously updates benchmark history and status markdown.
   - status dashboard: [`docs/BENCHMARK_STATUS.md`](docs/BENCHMARK_STATUS.md).
   - latest benchmark snapshot: `benchmarks/latest/kernel_hotpath_latest.json`.

--- a/docs/PERF_BUDGET.json
+++ b/docs/PERF_BUDGET.json
@@ -1,26 +1,80 @@
 {
-  "schema_version": 1,
-  "iterations_ci": 120000,
-  "thresholds": {
-    "scheduler_next": {
-      "min_ops_per_sec": 10000.0,
-      "max_ns_per_op": 100000.0
+  "schema_version": 2,
+  "profiles": {
+    "minimal": {
+      "iterations_ci": 90000,
+      "thresholds": {
+        "scheduler_next": {
+          "min_ops_per_sec": 8000.0,
+          "max_ns_per_op": 120000.0
+        },
+        "namespace_translate_local_to_global": {
+          "min_ops_per_sec": 8000.0,
+          "max_ns_per_op": 120000.0
+        },
+        "namespace_can_inspect": {
+          "min_ops_per_sec": 8000.0,
+          "max_ns_per_op": 120000.0
+        },
+        "ipc_reserve_send_plus_drain": {
+          "min_ops_per_sec": 8000.0,
+          "max_ns_per_op": 120000.0
+        },
+        "memory_charge_plus_release": {
+          "min_ops_per_sec": 8000.0,
+          "max_ns_per_op": 120000.0
+        }
+      }
     },
-    "namespace_translate_local_to_global": {
-      "min_ops_per_sec": 10000.0,
-      "max_ns_per_op": 100000.0
+    "desktop": {
+      "iterations_ci": 120000,
+      "thresholds": {
+        "scheduler_next": {
+          "min_ops_per_sec": 10000.0,
+          "max_ns_per_op": 100000.0
+        },
+        "namespace_translate_local_to_global": {
+          "min_ops_per_sec": 10000.0,
+          "max_ns_per_op": 100000.0
+        },
+        "namespace_can_inspect": {
+          "min_ops_per_sec": 10000.0,
+          "max_ns_per_op": 100000.0
+        },
+        "ipc_reserve_send_plus_drain": {
+          "min_ops_per_sec": 10000.0,
+          "max_ns_per_op": 100000.0
+        },
+        "memory_charge_plus_release": {
+          "min_ops_per_sec": 10000.0,
+          "max_ns_per_op": 100000.0
+        }
+      }
     },
-    "namespace_can_inspect": {
-      "min_ops_per_sec": 10000.0,
-      "max_ns_per_op": 100000.0
-    },
-    "ipc_reserve_send_plus_drain": {
-      "min_ops_per_sec": 10000.0,
-      "max_ns_per_op": 100000.0
-    },
-    "memory_charge_plus_release": {
-      "min_ops_per_sec": 10000.0,
-      "max_ns_per_op": 100000.0
+    "server": {
+      "iterations_ci": 150000,
+      "thresholds": {
+        "scheduler_next": {
+          "min_ops_per_sec": 12000.0,
+          "max_ns_per_op": 90000.0
+        },
+        "namespace_translate_local_to_global": {
+          "min_ops_per_sec": 12000.0,
+          "max_ns_per_op": 90000.0
+        },
+        "namespace_can_inspect": {
+          "min_ops_per_sec": 12000.0,
+          "max_ns_per_op": 90000.0
+        },
+        "ipc_reserve_send_plus_drain": {
+          "min_ops_per_sec": 12000.0,
+          "max_ns_per_op": 90000.0
+        },
+        "memory_charge_plus_release": {
+          "min_ops_per_sec": 12000.0,
+          "max_ns_per_op": 90000.0
+        }
+      }
     }
   }
 }

--- a/scripts/kernel_perf_budget_gate.py
+++ b/scripts/kernel_perf_budget_gate.py
@@ -58,6 +58,23 @@ def _check_thresholds(bench: dict, budget: dict) -> list[str]:
   return failures
 
 
+def _resolve_profile_budget(budget: dict, profile: str) -> dict:
+  if int(budget.get("schema_version", 0)) == 1:
+    return budget
+  if int(budget.get("schema_version", 0)) != 2:
+    raise ValueError("unsupported PERF_BUDGET schema_version")
+  profiles = budget.get("profiles", {})
+  if not isinstance(profiles, dict):
+    raise ValueError("PERF_BUDGET profiles missing or invalid")
+  if profile not in profiles:
+    known = ", ".join(sorted(profiles.keys()))
+    raise ValueError(f"unknown perf profile '{profile}', expected one of: {known}")
+  selected = profiles.get(profile, {})
+  if not isinstance(selected, dict):
+    raise ValueError(f"invalid profile config for '{profile}'")
+  return selected
+
+
 def main() -> int:
   parser = argparse.ArgumentParser(description="Kernel perf budget gate for cross-module hotpath benchmark.")
   parser.add_argument("--budget", default="docs/PERF_BUDGET.json")
@@ -65,32 +82,35 @@ def main() -> int:
                       help="Optional precomputed benchmark JSON path. If omitted, benchmark is executed.")
   parser.add_argument("--emit-benchmark-json", default=None,
                       help="Optional output path to write benchmark payload used by this gate.")
+  parser.add_argument("--profile", default="desktop",
+                      help="Perf budget profile (minimal|desktop|server).")
   args = parser.parse_args()
 
   repo_root = Path(__file__).resolve().parents[1]
   budget_path = repo_root / args.budget
   budget = _load_json(budget_path)
-  if int(budget.get("schema_version", 0)) != 1:
-    raise ValueError("unsupported PERF_BUDGET schema_version")
+  selected_budget = _resolve_profile_budget(budget, args.profile)
 
   if args.benchmark_json:
     bench = _load_json(repo_root / args.benchmark_json)
   else:
-    iterations = int(budget.get("iterations_ci", 120000))
+    iterations = int(selected_budget.get("iterations_ci", 120000))
     bench = _run_benchmark(repo_root, iterations)
 
   if args.emit_benchmark_json:
     out_path = repo_root / args.emit_benchmark_json
     out_path.write_text(json.dumps(bench, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
 
-  failures = _check_thresholds(bench, budget)
+  failures = _check_thresholds(bench, selected_budget)
   if failures:
     print("Kernel perf budget gate: FAILED")
+    print(f"profile={args.profile}")
     for line in failures:
       print(f"- {line}")
     return 1
 
   print("Kernel perf budget gate: PASSED")
+  print(f"profile={args.profile}")
   print(json.dumps(bench, sort_keys=True, separators=(",", ":")))
   return 0
 


### PR DESCRIPTION
## Summary
- upgrade PERF_BUDGET schema to v2 with per-profile thresholds (minimal, desktop, server)
- add --profile support to perf budget gate script
- run perf-budget workflow as profile matrix and upload per-profile artifacts
- update README perf-budget usage docs

## Validation
- python scripts/kernel_perf_budget_gate.py --profile minimal
- python scripts/kernel_perf_budget_gate.py --profile desktop
- python scripts/kernel_perf_budget_gate.py --profile server
- python scripts/run_clang_suite.py
- python -m pytest -q
- python scripts/validate_packages.py

## Issues
- closes #252