### PR TITLE
feat: implement #258 #259 #260 quality gates

### DIFF
--- a/.github/workflows/code-size-budget.yml
+++ b/.github/workflows/code-size-budget.yml
@@ -1,0 +1,28 @@
+﻿name: Code Size Budget
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "EXPLAIN.md"
+      - "CHANGELOG.md"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "EXPLAIN.md"
+      - "CHANGELOG.md"
+
+jobs:
+  code-size-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run code size budget gate
+        run: python scripts/code_size_budget_gate.py

--- a/.github/workflows/latency-gate.yml
+++ b/.github/workflows/latency-gate.yml
@@ -1,0 +1,32 @@
+﻿name: Scheduler Latency Gate
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "EXPLAIN.md"
+      - "CHANGELOG.md"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "EXPLAIN.md"
+      - "CHANGELOG.md"
+
+jobs:
+  latency-gate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [minimal, desktop, server]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run scheduler latency gate
+        run: python scripts/scheduler_latency_gate.py --profile ${{ matrix.profile }} --ticks 800 --seed 1337

--- a/.github/workflows/perf-scorecard.yml
+++ b/.github/workflows/perf-scorecard.yml
@@ -25,12 +25,15 @@ jobs:
       - name: Generate scorecard
         run: python scripts/perf_scorecard.py
 
+      - name: Enforce scorecard regression gate
+        run: python scripts/perf_scorecard_gate.py --min-samples 5 --max-relative-drop 0.05
+
       - name: Commit scorecard updates
         run: |
-          if [[ -n "$(git status --porcelain docs/PERF_SCORECARD.md benchmarks/latest/perf_scorecard_latest.json)" ]]; then
+          if [[ -n "$(git status --porcelain docs/PERF_SCORECARD.md benchmarks/latest/perf_scorecard_latest.json benchmarks/history/perf_scorecard_history.jsonl)" ]]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add docs/PERF_SCORECARD.md benchmarks/latest/perf_scorecard_latest.json
+            git add docs/PERF_SCORECARD.md benchmarks/latest/perf_scorecard_latest.json benchmarks/history/perf_scorecard_history.jsonl
             git commit -m "ci: update perf scorecard"
             git push
           fi

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ This repository contains:
   - wiki sources: [`docs/ALGORITHM_SOURCES.md`](docs/ALGORITHM_SOURCES.md).
 - [`Perf Scorecard workflow`](.github/workflows/perf-scorecard.yml) computes a composite engineering-performance score from latest benchmark artifacts.
   - scorecard dashboard: [`docs/PERF_SCORECARD.md`](docs/PERF_SCORECARD.md).
+  - regression gate: `python scripts/perf_scorecard_gate.py`.
+- [`Scheduler Latency Gate workflow`](.github/workflows/latency-gate.yml) enforces scheduler `p50/p95/p99` latency budgets by profile.
+  - policy: [`docs/LATENCY_BUDGET.json`](docs/LATENCY_BUDGET.json).
+- [`Code Size Budget workflow`](.github/workflows/code-size-budget.yml) enforces LOC budgets for core modules.
+  - policy: [`docs/CODE_SIZE_BUDGET.json`](docs/CODE_SIZE_BUDGET.json).
 - Snapshot schema ledger is validated in CI to prevent silent snapshot-contract drift.
   - ledger docs: [`docs/SNAPSHOT_SCHEMA_LEDGER.md`](docs/SNAPSHOT_SCHEMA_LEDGER.md).
   - machine ledger: [`docs/SNAPSHOT_SCHEMA_LEDGER.json`](docs/SNAPSHOT_SCHEMA_LEDGER.json).

--- a/benchmarks/history/perf_scorecard_history.jsonl
+++ b/benchmarks/history/perf_scorecard_history.jsonl
@@ -1,0 +1,2 @@
+{"algorithm_winner_score":1.0,"composite_score":194848886.73426,"has_algorithm_bench":true,"has_kernel_bench":true,"hotpath_score":274069838.1918,"schema_version":1,"test_pass_score":1.0,"winner_bonus":2}
+{"algorithm_winner_score":1.0,"composite_score":194848886.73426,"has_algorithm_bench":true,"has_kernel_bench":true,"hotpath_score":274069838.1918,"schema_version":1,"test_pass_score":1.0,"winner_bonus":2}

--- a/docs/CODE_SIZE_BUDGET.json
+++ b/docs/CODE_SIZE_BUDGET.json
@@ -1,0 +1,21 @@
+﻿{
+  "schema_version": 1,
+  "budgets": {
+    "kernel_c": {
+      "glob": "kernel/src/*.c",
+      "max_loc": 5200
+    },
+    "kernel_h": {
+      "glob": "kernel/include/*.h",
+      "max_loc": 900
+    },
+    "tests_c": {
+      "glob": "tests/*.c",
+      "max_loc": 5600
+    },
+    "scripts_py": {
+      "glob": "scripts/*.py",
+      "max_loc": 5200
+    }
+  }
+}

--- a/docs/LATENCY_BUDGET.json
+++ b/docs/LATENCY_BUDGET.json
@@ -1,0 +1,32 @@
+﻿{
+  "schema_version": 1,
+  "profiles": {
+    "minimal": {
+      "turbo": {
+        "max_p50_wait": 6,
+        "max_p95_wait": 7,
+        "max_p99_wait": 8,
+        "max_high_priority_p95_wait": 6,
+        "max_mean_wait": 5.5
+      }
+    },
+    "desktop": {
+      "turbo": {
+        "max_p50_wait": 6,
+        "max_p95_wait": 7,
+        "max_p99_wait": 8,
+        "max_high_priority_p95_wait": 6,
+        "max_mean_wait": 5.5
+      }
+    },
+    "server": {
+      "turbo": {
+        "max_p50_wait": 6,
+        "max_p95_wait": 7,
+        "max_p99_wait": 8,
+        "max_high_priority_p95_wait": 6,
+        "max_mean_wait": 5.5
+      }
+    }
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,4 +30,7 @@ Helper scripts for local development and automation live here.
 - `algorithm_selection_benchmark.py`: simulation benchmark that compares algorithm candidates (lookup and ready-pick strategies) and reports winners.
 - `algorithm_benchmark_monitor.py`: persists algorithm benchmark history/latest snapshots and regenerates `docs/ALGORITHM_LAB_STATUS.md`.
 - `perf_scorecard.py`: computes composite engineering performance score and regenerates `docs/PERF_SCORECARD.md`.
+- `perf_scorecard_gate.py`: enforces scorecard regression thresholds against recent history.
+- `scheduler_latency_gate.py`: enforces scheduler latency budgets (`p50/p95/p99`) from `docs/LATENCY_BUDGET.json`.
+- `code_size_budget_gate.py`: enforces LOC budgets from `docs/CODE_SIZE_BUDGET.json`.
 - `validate_snapshot_schema_ledger.py`: validates `docs/SNAPSHOT_SCHEMA_LEDGER.json` patterns against source to catch snapshot schema drift.

--- a/scripts/code_size_budget_gate.py
+++ b/scripts/code_size_budget_gate.py
@@ -1,0 +1,57 @@
+﻿#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+
+def _load_json(path: Path) -> dict:
+  data = json.loads(path.read_text(encoding="utf-8-sig"))
+  if not isinstance(data, dict):
+    raise ValueError(f"invalid JSON in {path}")
+  return data
+
+
+def _count_loc(path: Path) -> int:
+  loc = 0
+  for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+    s = line.strip()
+    if not s or s.startswith("//") or s.startswith("#"):
+      continue
+    loc += 1
+  return loc
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Code size budget gate")
+  parser.add_argument("--budget", default="docs/CODE_SIZE_BUDGET.json")
+  args = parser.parse_args()
+
+  root = Path(__file__).resolve().parents[1]
+  budget = _load_json(root / args.budget)
+  budgets = budget.get("budgets", {})
+  failures = []
+  report = {}
+
+  for name, cfg in budgets.items():
+    glob = str(cfg.get("glob", ""))
+    max_loc = int(cfg.get("max_loc", 0))
+    files = sorted(root.glob(glob))
+    total = sum(_count_loc(p) for p in files if p.is_file())
+    report[name] = {"glob": glob, "max_loc": max_loc, "actual_loc": total, "file_count": len(files)}
+    if total > max_loc:
+      failures.append(f"{name}: {total} > {max_loc} ({glob})")
+
+  if failures:
+    print("Code size budget gate: FAILED")
+    for f in failures:
+      print(f"- {f}")
+    print(json.dumps(report, sort_keys=True, separators=(",", ":")))
+    return 1
+
+  print("Code size budget gate: PASSED")
+  print(json.dumps(report, sort_keys=True, separators=(",", ":")))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/perf_scorecard.py
+++ b/scripts/perf_scorecard.py
@@ -86,6 +86,10 @@ def main() -> int:
   latest_json = root / "benchmarks" / "latest" / "perf_scorecard_latest.json"
   latest_json.parent.mkdir(parents=True, exist_ok=True)
   latest_json.write_text(json.dumps(out, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+  history_jsonl = root / "benchmarks" / "history" / "perf_scorecard_history.jsonl"
+  history_jsonl.parent.mkdir(parents=True, exist_ok=True)
+  with history_jsonl.open("a", encoding="utf-8") as f:
+    f.write(json.dumps(out, sort_keys=True, separators=(",", ":")) + "\n")
 
   md = _render_md(out)
   (root / "docs" / "PERF_SCORECARD.md").write_text(md, encoding="utf-8")

--- a/scripts/perf_scorecard_gate.py
+++ b/scripts/perf_scorecard_gate.py
@@ -1,0 +1,62 @@
+﻿#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+
+def _load_history(path: Path) -> list[dict]:
+  if not path.exists():
+    return []
+  rows = []
+  for line in path.read_text(encoding="utf-8").splitlines():
+    line = line.strip()
+    if not line:
+      continue
+    try:
+      payload = json.loads(line)
+      if isinstance(payload, dict):
+        rows.append(payload)
+    except json.JSONDecodeError:
+      continue
+  return rows
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Perf scorecard threshold gate")
+  parser.add_argument("--history", default="benchmarks/history/perf_scorecard_history.jsonl")
+  parser.add_argument("--max-relative-drop", type=float, default=0.05)
+  parser.add_argument("--min-samples", type=int, default=5)
+  args = parser.parse_args()
+
+  root = Path(__file__).resolve().parents[1]
+  rows = _load_history(root / args.history)
+  if len(rows) < args.min_samples:
+    print("Perf scorecard gate: PASSED")
+    print(f"insufficient_history={len(rows)}")
+    return 0
+
+  current = float(rows[-1].get("composite_score", 0.0))
+  baseline_slice = rows[-args.min_samples:-1]
+  baseline = sum(float(r.get("composite_score", 0.0)) for r in baseline_slice) / max(1, len(baseline_slice))
+  if baseline <= 0:
+    print("Perf scorecard gate: PASSED")
+    print("baseline_non_positive")
+    return 0
+
+  relative_drop = (baseline - current) / baseline
+  if relative_drop > args.max_relative_drop:
+    print("Perf scorecard gate: FAILED")
+    print(f"current={current}")
+    print(f"baseline={baseline}")
+    print(f"relative_drop={relative_drop}")
+    return 1
+
+  print("Perf scorecard gate: PASSED")
+  print(f"current={current}")
+  print(f"baseline={baseline}")
+  print(f"relative_drop={relative_drop}")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/scheduler_latency_gate.py
+++ b/scripts/scheduler_latency_gate.py
@@ -1,0 +1,79 @@
+﻿#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_json(path: Path) -> dict:
+  data = json.loads(path.read_text(encoding="utf-8-sig"))
+  if not isinstance(data, dict):
+    raise ValueError(f"invalid JSON object in {path}")
+  return data
+
+
+def _run_scheduler_bench(root: Path, ticks: int, seed: int) -> dict:
+  cmd = [
+      sys.executable,
+      str(root / "scripts" / "scheduler_turbo_benchmark.py"),
+      "--ticks",
+      str(ticks),
+      "--seed",
+      str(seed),
+  ]
+  out = subprocess.run(cmd, cwd=root, capture_output=True, text=True, check=True)
+  payload = json.loads(out.stdout)
+  if not isinstance(payload, dict):
+    raise ValueError("scheduler benchmark output invalid")
+  return payload
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Scheduler latency budget gate (p50/p95/p99).")
+  parser.add_argument("--budget", default="docs/LATENCY_BUDGET.json")
+  parser.add_argument("--profile", default="desktop")
+  parser.add_argument("--ticks", type=int, default=800)
+  parser.add_argument("--seed", type=int, default=1337)
+  args = parser.parse_args()
+
+  root = Path(__file__).resolve().parents[1]
+  budget = _load_json(root / args.budget)
+  profiles = budget.get("profiles", {})
+  if args.profile not in profiles:
+    raise ValueError(f"unknown profile '{args.profile}'")
+  limits = profiles[args.profile]["turbo"]
+
+  bench = _run_scheduler_bench(root, args.ticks, args.seed)
+  turbo = bench.get("turbo", {})
+
+  checks = [
+      ("p50_wait", "max_p50_wait"),
+      ("p95_wait", "max_p95_wait"),
+      ("p99_wait", "max_p99_wait"),
+      ("high_priority_p95_wait", "max_high_priority_p95_wait"),
+      ("mean_wait", "max_mean_wait"),
+  ]
+
+  failures = []
+  for metric_key, max_key in checks:
+    actual = float(turbo.get(metric_key, 0))
+    allowed = float(limits.get(max_key, 0))
+    if actual > allowed:
+      failures.append(f"{metric_key}: {actual} > {allowed}")
+
+  if failures:
+    print("Scheduler latency gate: FAILED")
+    print(f"profile={args.profile}")
+    for f in failures:
+      print(f"- {f}")
+    return 1
+
+  print("Scheduler latency gate: PASSED")
+  print(f"profile={args.profile}")
+  print(json.dumps(bench, sort_keys=True, separators=(",", ":")))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/scheduler_turbo_benchmark.py
+++ b/scripts/scheduler_turbo_benchmark.py
@@ -32,11 +32,11 @@ def _pick_turbo(tasks: List[Task], now_tick: int, wait_weight: int = 2, priority
   return best_idx
 
 
-def _p95(values: List[int]) -> int:
+def _percentile(values: List[int], pct: float) -> int:
   if not values:
     return 0
   ordered = sorted(values)
-  idx = int(0.95 * (len(ordered) - 1))
+  idx = int(pct * (len(ordered) - 1))
   return ordered[idx]
 
 
@@ -83,8 +83,10 @@ def simulate(strategy: str, ticks: int = 300, seed: int = 1337) -> Dict[str, obj
       "strategy": strategy,
       "ticks": ticks,
       "mean_wait": round(sum(wait_samples) / len(wait_samples), 3),
-      "p95_wait": _p95(wait_samples),
-      "high_priority_p95_wait": _p95(high_priority_wait_samples),
+      "p50_wait": _percentile(wait_samples, 0.50),
+      "p95_wait": _percentile(wait_samples, 0.95),
+      "p99_wait": _percentile(wait_samples, 0.99),
+      "high_priority_p95_wait": _percentile(high_priority_wait_samples, 0.95),
       "max_wait": max(wait_samples),
       "per_task": per_task,
   }
@@ -101,7 +103,9 @@ def compare(ticks: int = 300, seed: int = 1337) -> Dict[str, object]:
       "turbo": turbo,
       "delta": {
           "mean_wait_improvement": round(rr["mean_wait"] - turbo["mean_wait"], 3),
+          "p50_wait_improvement": rr["p50_wait"] - turbo["p50_wait"],
           "p95_wait_improvement": rr["p95_wait"] - turbo["p95_wait"],
+          "p99_wait_improvement": rr["p99_wait"] - turbo["p99_wait"],
           "high_priority_p95_wait_improvement": rr["high_priority_p95_wait"] - turbo["high_priority_p95_wait"],
           "max_wait_improvement": rr["max_wait"] - turbo["max_wait"],
       },


### PR DESCRIPTION
## Summary
- implement #258 with perf scorecard regression gate (scripts/perf_scorecard_gate.py) and history tracking
- implement #259 with scheduler latency gate (p50/p95/p99) plus profile budgets
- implement #260 with code-size budget gate and CI workflow
- update scheduler benchmark payload to include p50/p99 metrics
- wire docs and workflows

## Validation
- python scripts/scheduler_latency_gate.py --profile desktop --ticks 800 --seed 1337
- python scripts/code_size_budget_gate.py
- python scripts/perf_scorecard.py
- python scripts/perf_scorecard_gate.py --min-samples 2 --max-relative-drop 0.2
- python -m pytest -q

## Issues
- closes #258
- closes #259
- closes #260